### PR TITLE
update from upstream

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -46,6 +46,7 @@ const prettierConfig = {
             },
         },
     ],
+    plugins: ["prettier-plugin-sh"],
 };
 
 module.exports = prettierConfig;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "async-stream"
@@ -227,9 +227,9 @@ checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cc"
-version = "1.2.14"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "shlex",
 ]
@@ -792,9 +792,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matchers"
@@ -1171,18 +1171,18 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1191,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,17 @@ FROM --platform=${BUILDPLATFORM} rust:1.85.0@sha256:ad7e5fd44a71f317c88993a64d40
 ARG APPLICATION_NAME
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \
-    && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
+    && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
 # borrowed (Ba Dum Tss!) from
 # https://github.com/pablodeymo/rust-musl-builder/blob/7a7ea3e909b1ef00c177d9eeac32d8c9d7d6a08c/Dockerfile#L48-L49
 RUN --mount=type=cache,id=apt-cache-amd64,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib-amd64,target=/var/lib/apt,sharing=locked \
-    apt-get update && \
-    apt-get --no-install-recommends install --yes \
-    build-essential \
-    musl-dev \
-    musl-tools
+    apt-get update \
+    && apt-get --no-install-recommends install --yes \
+        build-essential \
+        musl-dev \
+        musl-tools
 
 FROM rust-base AS rust-linux-amd64
 ARG TARGET=x86_64-unknown-linux-musl
@@ -22,11 +22,11 @@ FROM rust-base AS rust-linux-arm64
 ARG TARGET=aarch64-unknown-linux-musl
 RUN --mount=type=cache,id=apt-cache-arm64,from=rust-base,source=/var/cache/apt,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib-arm64,from=rust-base,source=/var/lib/apt,target=/var/lib/apt,sharing=locked \
-    dpkg --add-architecture arm64 && \
-    apt-get update && \
-    apt-get --no-install-recommends install --yes \
-    libc6-dev-arm64-cross \
-    gcc-aarch64-linux-gnu
+    dpkg --add-architecture arm64 \
+    && apt-get update \
+    && apt-get --no-install-recommends install --yes \
+        libc6-dev-arm64-cross \
+        gcc-aarch64-linux-gnu
 
 FROM rust-${TARGETPLATFORM//\//-} AS rust-cargo-build
 
@@ -65,9 +65,9 @@ RUN --mount=type=cache,target=/build/${APPLICATION_NAME}/target \
 
 FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS passwd-build
 
-RUN addgroup --gid 900 appgroup && \
-    # setting `--system` prevents prompting for a password
-    adduser --ingroup appgroup --uid 900 --system --shell /bin/false appuser
+# setting `--system` prevents prompting for a password
+RUN addgroup --gid 900 appgroup \
+    && adduser --ingroup appgroup --uid 900 --system --shell /bin/false appuser
 
 RUN cat /etc/group | grep appuser > /tmp/group_appuser
 RUN cat /etc/passwd | grep appuser > /tmp/passwd_appuser

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "devDependencies": {
         "@actions/tool-cache": "2.0.2",
-        "prettier": "3.5.1"
+        "prettier": "3.5.1",
+        "prettier-plugin-sh": "0.15.0"
       },
       "engines": {
         "node": ">=22.14.0",
@@ -80,6 +81,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/mvdan-sh": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/mvdan-sh/-/mvdan-sh-0.10.1.tgz",
+      "integrity": "sha512-kMbrH0EObaKmK3nVRKUIIya1dpASHIEusM13S4V1ViHFuxuNxCo+arxoa6j/dbV22YBGjl7UKJm9QQKJ2Crzhg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/prettier": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
@@ -96,6 +104,26 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-sh": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sh/-/prettier-plugin-sh-0.15.0.tgz",
+      "integrity": "sha512-U0PikJr/yr2bzzARl43qI0mApBj0C1xdAfA04AZa6LnvIKawXHhuy2fFo6LNA7weRzGlAiNbaEFfKMFo0nZr/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mvdan-sh": "^0.10.1",
+        "sh-syntax": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.3"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -105,6 +133,29 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/sh-syntax": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/sh-syntax/-/sh-syntax-0.4.2.tgz",
+      "integrity": "sha512-/l2UZ5fhGZLVZa16XQM9/Vq/hezGGbdHeVEA01uWjOL1+7Ek/gt6FquW0iKKws4a9AYPYvlz6RyVvjh3JxOteg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/kristof-mattei/wsdd-rs#readme",
   "devDependencies": {
     "@actions/tool-cache": "2.0.2",
-    "prettier": "3.5.1"
+    "prettier": "3.5.1",
+    "prettier-plugin-sh": "0.15.0"
   },
   "publishConfig": {
     "access": "restricted"


### PR DESCRIPTION
- **chore(deps): update rust to v1.83.0**
- **chore(deps): update node.js to v22.14.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.108.0**
- **chore(deps): update dependency prettier to v3.5.1**
- **chore(deps): update alpine docker tag to v3.21.3**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/cache action to v4.2.1**
- **chore(deps): update docker/build-push-action action to v6.14.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.109.0**
- **chore(deps): update codecov/test-results-action action to v1.0.4**
- **chore(deps): update actions-rs-plus/clippy-check action to v2.2.1**
- **chore: format dockerfile**
- **chore: fmt also 1.85.0**
- **chore(deps): update rust docker tag to v1.85.0**
- **chore(deps): update rust:1.85.0 docker digest to ad7e5fd**
