### PR TITLE
update from upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "wsdd-rs"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2024"
-rust-version = "1.85.1"
+rust-version = "1.86.0"
 authors = ["Kristof Mattei"]
 description = "Rust seed application"
 license-file = "LICENSE"
@@ -23,6 +23,9 @@ perf = "warn"
 style = "warn"
 suspicious = "warn"
 
+# this one is debatable. continue is used in places to be explicit, and to guard against
+# issues when refactoring
+needless_continue = { level = "allow", priority = 127 }
 # this one causes confusion when combining variables (`foo`) and
 # dereferenced variables (`foo.bar`). The latter cannot be inlined
 # so we don't inline anything

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.86.0"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.114.0**
- **chore(deps): update github/codeql-action action to v3.28.13**
- **chore(deps): update returntocorp/semgrep docker tag to v1.116.0**
- **chore(deps): update dependency prettier-plugin-sh to v0.16.0**
- **chore(deps): lock file maintenance**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.19.0**
- **chore(deps): update rui314/setup-mold digest to e16410e**
- **chore(deps): update returntocorp/semgrep docker tag to v1.117.0**
- **chore: clippy 1.86 fixes**
- **chore(deps): update rust docker tag to v1.86.0**
- **chore(deps): update rust to v1.86.0**
