### PR TITLE
probe no host header

### DIFF
--- a/src/soap/builder.rs
+++ b/src/soap/builder.rs
@@ -240,11 +240,7 @@ impl<'config> Builder<'config> {
             WSA_DISCOVERY,
             WSD_PROBE,
             None,
-            #[expect(
-                clippy::redundant_closure_for_method_calls,
-                reason = "lifetimes aren't passed when using function pointer"
-            )]
-            Some(|builder, element| builder.add_wsd_host_header_elements(element)),
+            None,
             Some(&writer.into_inner().into_inner()),
         )?;
 


### PR DESCRIPTION
- **fix: add probe examples**
- **fix: probes don't have host (`AppSequence`) headers**
