### PR TITLE
feat: expanded header extraction

### DIFF
--- a/src/soap/builder.rs
+++ b/src/soap/builder.rs
@@ -55,7 +55,7 @@ impl<'config> Builder<'config> {
         &mut self,
         to_addr: &str,
         action: &str,
-        relates_to: Option<&str>,
+        relates_to: Option<Urn>,
         add_extra_headers: Option<ExtraHeadersCallback>,
         body: Option<&[u8]>,
     ) -> Result<(Vec<u8>, Urn), quick_xml::errors::Error> {
@@ -80,7 +80,7 @@ impl<'config> Builder<'config> {
         &mut self,
         to_addr: &str,
         action: &str,
-        relates_to: Option<&str>,
+        relates_to: Option<Urn>,
         add_extra_headers: Option<ExtraHeadersCallback>,
         body: Option<&[u8]>,
     ) -> Result<(Vec<u8>, Urn), quick_xml::errors::Error> {
@@ -112,7 +112,9 @@ impl<'config> Builder<'config> {
                 if let Some(relates_to) = relates_to {
                     writer
                         .create_element("wsa:RelatesTo")
-                        .write_text_content(BytesText::new(relates_to))?;
+                        .write_text_content(BytesText::new(
+                            relates_to.encode_lower(&mut Uuid::encode_buffer()),
+                        ))?;
                 }
 
                 if let Some(add_extra_headers) = add_extra_headers {
@@ -280,7 +282,7 @@ impl<'config> Builder<'config> {
     pub fn build_resolve_matches(
         config: &Config,
         address: IpAddr,
-        relates_to: &str,
+        relates_to: Urn,
     ) -> Result<Vec<u8>, quick_xml::errors::Error> {
         let mut builder = Builder::new(config);
 
@@ -323,7 +325,7 @@ impl<'config> Builder<'config> {
 
     pub fn build_probe_matches(
         config: &Config,
-        relates_to: &str,
+        relates_to: Urn,
     ) -> Result<Vec<u8>, quick_xml::errors::Error> {
         let mut builder = Builder::new(config);
 

--- a/src/soap/parser.rs
+++ b/src/soap/parser.rs
@@ -13,40 +13,58 @@ use quick_xml::reader::NsReader;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{Level, event};
+use uuid::fmt::Urn;
 
 use crate::constants::{WSA_URI, XML_SOAP_NAMESPACE};
 use crate::max_size_deque::MaxSizeDeque;
 use crate::network_address::NetworkAddress;
 
 pub struct MessageHandler {
-    handled_messages: Arc<RwLock<MaxSizeDeque<String>>>,
+    handled_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
     network_address: NetworkAddress,
 }
 
-struct Header<'r> {
-    message_id: Option<Cow<'r, str>>,
-    action: Option<Cow<'r, str>>,
+pub struct Header<'r> {
+    #[expect(unused, reason = "WIP")]
+    pub to: Option<Cow<'r, str>>,
+    pub action: Cow<'r, str>,
+    pub message_id: Urn,
+    pub relates_to: Option<Urn>,
 }
 
-type ParsedHeader<'r> = Result<Header<'r>, quick_xml::errors::Error>;
+type ParsedHeader<'r> = Result<Header<'r>, HeaderError>;
 
 #[derive(Error, Debug)]
 pub enum MessageHandlerError {
+    #[error("Missing Header")]
+    MissingHeader,
     #[error("Missing Body")]
     MissingBody,
+    #[error("Message already processed")]
+    DuplicateMessage,
+    #[error("Error parsing XML")]
+    XmlError(#[from] quick_xml::errors::Error),
+    #[error("Header Error")]
+    HeaderError(#[from] HeaderError),
+}
+
+#[derive(Error, Debug)]
+pub enum HeaderError {
     #[error("Missing Message Id")]
     MissingMessageId,
     #[error("Missing Action")]
     MissingAction,
-    #[error("Message already processed")]
-    DuplicateMessage,
+    #[error("Invalid Message Id")]
+    InvalidMessageId(uuid::Error),
+    #[error("Invalid Relates To")]
+    InvalidRelatesTo(uuid::Error),
     #[error("Error parsing XML")]
     XmlError(#[from] quick_xml::errors::Error),
 }
 
 impl MessageHandler {
     pub fn new(
-        handled_messages: Arc<RwLock<MaxSizeDeque<String>>>,
+        handled_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
         network_address: NetworkAddress,
     ) -> Self {
         Self {
@@ -60,11 +78,10 @@ impl MessageHandler {
         &self,
         raw: &'r [u8],
         src: Option<SocketAddr>,
-    ) -> Result<(Cow<'r, str>, Cow<'r, str>, NsReader<&'r [u8]>), MessageHandlerError> {
+    ) -> Result<(Header<'r>, NsReader<&'r [u8]>), MessageHandlerError> {
         let mut reader = NsReader::from_reader(raw);
 
-        let mut message_id = None;
-        let mut action = None;
+        let mut header = None;
         let mut has_body = false;
 
         // as per https://www.w3.org/TR/soap12/#soapenvelope, the Header, Body order is fixed. We don't need to code for Body, Header
@@ -73,10 +90,7 @@ impl MessageHandler {
                 (Bound(Namespace(ns)), Event::Start(e)) => {
                     if ns == XML_SOAP_NAMESPACE.as_bytes() {
                         if e.name().local_name().as_ref() == b"Header" {
-                            let header = parse_header(&mut reader)?;
-
-                            message_id = header.message_id;
-                            action = header.action;
+                            header = Some(parse_header(&mut reader)?);
                         } else if e.name().local_name().as_ref() == b"Body" {
                             has_body = true;
                             break;
@@ -92,23 +106,23 @@ impl MessageHandler {
             }
         }
 
-        let Some(message_id) = message_id else {
-            return Err(MessageHandlerError::MissingMessageId);
-        };
-
-        let Some(action) = action else {
-            return Err(MessageHandlerError::MissingAction);
+        let Some(header) = header else {
+            return Err(MessageHandlerError::MissingHeader);
         };
 
         // check for duplicates
-        if self.is_duplicated_msg(message_id.as_ref()).await {
-            event!(Level::DEBUG, "known message ({}): dropping it", message_id);
+        if self.is_duplicated_msg(header.message_id).await {
+            event!(
+                Level::DEBUG,
+                "known message ({}): dropping it",
+                header.message_id
+            );
 
             // TODO improve reason
             return Err(MessageHandlerError::DuplicateMessage);
         }
 
-        let action_method = action.rsplit_once('/').unwrap().1;
+        let action_method = header.action.rsplit_once('/').unwrap().1;
 
         if let Some(src) = src {
             event!(
@@ -117,7 +131,7 @@ impl MessageHandler {
                 src,
                 self.network_address.interface,
                 action_method,
-                message_id
+                header.message_id
             );
         } else {
             // http logging is already done by according server
@@ -125,7 +139,7 @@ impl MessageHandler {
                 Level::DEBUG,
                 "processing WSD {} message ({})",
                 action_method,
-                message_id
+                header.message_id
             );
         }
 
@@ -139,11 +153,11 @@ impl MessageHandler {
             String::from_utf8_lossy(raw)
         );
 
-        Ok((message_id, action, reader))
+        Ok((header, reader))
     }
 
     /// Implements SOAP-over-UDP Appendix II Item 2
-    async fn is_duplicated_msg(&self, message_id: &str) -> bool {
+    async fn is_duplicated_msg(&self, message_id: Urn) -> bool {
         // reverse iter, as it is more likely that we see a message that we just saw vs one we've seen little earlier
         if self
             .handled_messages
@@ -151,14 +165,11 @@ impl MessageHandler {
             .await
             .iter()
             .rev()
-            .any(|m| m == message_id)
+            .any(|&m| m == message_id)
         {
             true
         } else {
-            self.handled_messages
-                .write()
-                .await
-                .push_back(message_id.to_owned());
+            self.handled_messages.write().await.push_back(message_id);
 
             false
         }
@@ -166,20 +177,48 @@ impl MessageHandler {
 }
 
 fn parse_header<'r>(reader: &mut NsReader<&'r [u8]>) -> ParsedHeader<'r> {
-    let mut message_id = None;
+    // <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    // <wsa:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/ProbeMatches</wsa:Action>
+    // <wsa:MessageID>urn:uuid:ae0a8a7b-0138-11f0-8bff-d45ddf1e11a9</wsa:MessageID>
+    // <wsa:RelatesTo>urn:uuid:ff876786-d5fd-4cc5-825b-fc494834cf19</wsa:RelatesTo>
+    // <wsd:AppSequence InstanceId="1742000334" SequenceId="urn:uuid:ae0a8b77-0138-11f0-93f3-d45ddf1e11a9" MessageNumber="1" />
+    let mut to = None;
     let mut action = None;
+    let mut message_id = None;
+    let mut relates_to = None;
 
     loop {
         match reader.read_resolved_event()? {
             (Bound(Namespace(ns)), Event::Start(e)) => {
                 if ns == WSA_URI.as_bytes() {
                     // header items can be in any order, as per SOAP 1.1 and 1.2
-                    if e.name().local_name().as_ref() == b"MessageID" {
-                        message_id = Some(reader.read_text(e.to_end().name())?);
-                    } else if e.name().local_name().as_ref() == b"Action" {
-                        action = Some(reader.read_text(e.to_end().name())?);
-                    } else {
-                        // Not a match, continue
+                    match e.name().local_name().as_ref() {
+                        b"To" => {
+                            to = Some(reader.read_text(e.to_end().name())?);
+                        },
+                        b"Action" => {
+                            action = Some(reader.read_text(e.to_end().name())?);
+                        },
+                        b"MessageID" => {
+                            let m_id = reader.read_text(e.to_end().name())?;
+
+                            let m_id =
+                                m_id.parse::<Urn>().map_err(HeaderError::InvalidMessageId)?;
+
+                            message_id = Some(m_id);
+                        },
+                        b"RelatesTo" => {
+                            let r_to = reader.read_text(e.to_end().name())?;
+
+                            let r_to =
+                                r_to.parse::<Urn>().map_err(HeaderError::InvalidRelatesTo)?;
+
+                            relates_to = Some(r_to);
+                        },
+                        _ => {
+
+                            // Not a match, continue
+                        },
                     }
                 }
             },
@@ -194,5 +233,18 @@ fn parse_header<'r>(reader: &mut NsReader<&'r [u8]>) -> ParsedHeader<'r> {
         }
     }
 
-    Ok(Header { message_id, action })
+    let Some(message_id) = message_id else {
+        return Err(HeaderError::MissingMessageId);
+    };
+
+    let Some(action) = action else {
+        return Err(HeaderError::MissingAction);
+    };
+
+    Ok(Header {
+        to,
+        action,
+        message_id,
+        relates_to,
+    })
 }

--- a/src/wsd/udp.rs
+++ b/src/wsd/udp.rs
@@ -4,8 +4,9 @@ pub mod host;
 use std::sync::{Arc, LazyLock};
 
 use tokio::sync::RwLock;
+use uuid::fmt::Urn;
 
 use crate::max_size_deque::MaxSizeDeque;
 
-static HANDLED_MESSAGES: LazyLock<Arc<RwLock<MaxSizeDeque<String>>>> =
+static HANDLED_MESSAGES: LazyLock<Arc<RwLock<MaxSizeDeque<Urn>>>> =
     LazyLock::new(|| Arc::new(RwLock::new(MaxSizeDeque::new(10))));


### PR DESCRIPTION
`header`'s `message_id` and `relates_to` (if provided) are now validated as `Urn`
