### PR TITLE
chore: change how event is written separating text from variables

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,31 @@
         {
             "type": "lldb",
             "request": "launch",
+            "name": "Debug executable 'wsdd-rs' with --version",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=wsdd-rs",
+                    "--package=wsdd-rs",
+                    "--features=tokio-console"
+                ],
+                "filter": {
+                    "name": "wsdd-rs",
+                    "kind": "bin"
+                }
+            },
+            "args": ["-V"],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "RUST_BACKTRACE": "1",
+                "RUST_LOG": "DEBUG,wsdd_rs=TRACE"
+            },
+            "internalConsoleOptions": "neverOpen",
+            "terminal": "integrated"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
             "name": "Debug executable 'wsdd-rs' with incorrect uuid",
             "cargo": {
                 "args": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,11 @@
     "lldb.launch.expressions": "simple",
     "lldb.launch.terminal": "integrated",
     "prettier.configPath": "./prettier.config.mjs",
+    "rust-analyzer.cargo.extraEnv": {
+        // "RUSTC_BOOTSTRAP": "1"
+    },
     "rust-analyzer.runnables.extraEnv": {
+        // "RUSTC_BOOTSTRAP": "1",
         "RUST_LOG": "DEBUG,wsdd_rs=TRACE"
     },
     "rust-analyzer.cargo.features": ["tokio-console"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -297,7 +297,7 @@ fn get_uuid_from_machine() -> Result<Uuid, eyre::Report> {
         None => uuid::Uuid::new_v5(&Uuid::NAMESPACE_DNS, gethostname()?.as_bytes()),
     };
 
-    event!(Level::INFO, "using pre-defined UUID {}", uuid);
+    event!(Level::INFO, %uuid, "using pre-defined UUID");
 
     Ok(uuid)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,6 @@ pub enum PortOrSocket {
 
 impl Config {
     pub fn log(&self) {
-        event!(Level::INFO, "{:?}", self);
+        event!(Level::INFO, ?self);
     }
 }


### PR DESCRIPTION
also added test for easy launching w/ `--version`, and added the `RUSTC_BOOTSTRAP` placeholders
