### PR TITLE
chore: switch crate as const_format relies on outdated version of const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,24 +376,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_format"
-version = "0.2.35"
+name = "const-str"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
 dependencies = [
- "const_format_proc_macros",
- "konst",
+ "const-str-proc-macro",
 ]
 
 [[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
+name = "const-str-proc-macro"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+checksum = "1c7e7913ec01ed98b697e62f8d3fd63c86dc6cccaf983c7eebc64d0e563b0ad9"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "syn",
 ]
 
 [[package]]
@@ -1030,21 +1029,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "konst"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330f0e13e6483b8c34885f7e6c9f19b1a7bd449c673fbb948a51c99d66ef74f4"
-dependencies = [
- "konst_macro_rules",
-]
-
-[[package]]
-name = "konst_macro_rules"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -2588,7 +2572,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "console-subscriber",
- "const_format",
+ "const-str",
  "delegate",
  "dotenvy",
  "hashbrown 0.17.0",

--- a/crates/wsdd-rs/Cargo.toml
+++ b/crates/wsdd-rs/Cargo.toml
@@ -28,7 +28,7 @@ bytes = "1.11.1"
 clap = { version = "4.6.0", features = ["cargo", "string", "derive"] }
 color-eyre = "0.6.5"
 console-subscriber = { version = "0.5.0", optional = true }
-const_format = { version = "0.2.35", features = ["fmt"] }
+const-str = { version = "1.1.0", features = ["proc"] }
 delegate = "0.13.5"
 dotenvy = "0.15.7"
 hashbrown = { version = "0.17.0", default-features = false, features = [

--- a/crates/wsdd-rs/src/constants.rs
+++ b/crates/wsdd-rs/src/constants.rs
@@ -1,7 +1,7 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::num::NonZeroU16;
 
-use const_format::concatcp;
+use const_str::format as const_format;
 
 // # constants for WSD XML/SOAP parsing
 // WSA_URI: str = 'http://schemas.xmlsoap.org/ws/2004/08/addressing'
@@ -32,38 +32,38 @@ pub const XML_PUB_NAMESPACE: &str = "http://schemas.microsoft.com/windows/pub/20
 // WSD_MAX_KNOWN_MESSAGES: int = 10
 
 // WSD_PROBE: str = WSD_URI + '/Probe'
-pub const WSD_PROBE: &str = concatcp!(WSD_URI, "/Probe");
+pub const WSD_PROBE: &str = const_format!("{}{}", WSD_URI, "/Probe");
 // WSD_PROBE_MATCH: str = WSD_URI + '/ProbeMatches'
-pub const WSD_PROBE_MATCH: &str = concatcp!(WSD_URI, "/ProbeMatches");
+pub const WSD_PROBE_MATCH: &str = const_format!("{}{}", WSD_URI, "/ProbeMatches");
 // WSD_RESOLVE: str = WSD_URI + '/Resolve'
-pub const WSD_RESOLVE: &str = concatcp!(WSD_URI, "/Resolve");
+pub const WSD_RESOLVE: &str = const_format!("{}{}", WSD_URI, "/Resolve");
 // WSD_RESOLVE_MATCH: str = WSD_URI + '/ResolveMatches'
-pub const WSD_RESOLVE_MATCH: &str = concatcp!(WSD_URI, "/ResolveMatches");
+pub const WSD_RESOLVE_MATCH: &str = const_format!("{}{}", WSD_URI, "/ResolveMatches");
 // WSD_HELLO: str = WSD_URI + '/Hello'
-pub const WSD_HELLO: &str = concatcp!(WSD_URI, "/Hello");
+pub const WSD_HELLO: &str = const_format!("{}{}", WSD_URI, "/Hello");
 // WSD_BYE: str = WSD_URI + '/Bye'
-pub const WSD_BYE: &str = concatcp!(WSD_URI, "/Bye");
+pub const WSD_BYE: &str = const_format!("{}{}", WSD_URI, "/Bye");
 // WSD_GET: str = 'http://schemas.xmlsoap.org/ws/2004/09/transfer/Get'
 pub const WSD_GET: &str = "http://schemas.xmlsoap.org/ws/2004/09/transfer/Get";
 // WSD_GET_RESPONSE: str = 'http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse'
 pub const WSD_GET_RESPONSE: &str = "http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse";
 
 pub const WSDP_THIS_DEVICE: &str = "ThisDevice";
-pub const WSDP_THIS_DEVICE_DIALECT: &str = concatcp!(WSDP_URI, "/", WSDP_THIS_DEVICE);
+pub const WSDP_THIS_DEVICE_DIALECT: &str = const_format!("{}/{}", WSDP_URI, WSDP_THIS_DEVICE);
 pub const WSDP_THIS_MODEL: &str = "ThisModel";
-pub const WSDP_THIS_MODEL_DIALECT: &str = concatcp!(WSDP_URI, "/", WSDP_THIS_MODEL);
+pub const WSDP_THIS_MODEL_DIALECT: &str = const_format!("{}/{}", WSDP_URI, WSDP_THIS_MODEL);
 pub const WSDP_RELATIONSHIP: &str = "Relationship";
-pub const WSDP_RELATIONSHIP_DIALECT: &str = concatcp!(WSDP_URI, "/", WSDP_RELATIONSHIP);
+pub const WSDP_RELATIONSHIP_DIALECT: &str = const_format!("{}/{}", WSDP_URI, WSDP_RELATIONSHIP);
 pub const WSDP_RELATIONSHIP_HOST: &str = "host";
-pub const WSDP_RELATIONSHIP_TYPE_HOST: &str = concatcp!(WSDP_URI, "/", WSDP_RELATIONSHIP_HOST);
+pub const WSDP_RELATIONSHIP_TYPE_HOST: &str =
+    const_format!("{}/{}", WSDP_URI, WSDP_RELATIONSHIP_HOST);
 
 // WSD_TYPE_DEVICE: str = 'wsdp:Device'
 pub const WSDP_TYPE_DEVICE: &str = "wsdp:Device";
 // PUB_COMPUTER: str = 'pub:Computer'
 pub const PUB_COMPUTER: &str = "pub:Computer";
 // WSD_TYPE_DEVICE_COMPUTER: str = '{0} {1}'.format(WSD_TYPE_DEVICE, PUB_COMPUTER)
-// TODO: fix when format_args!() becomes const
-pub const WSDP_TYPE_DEVICE_COMPUTER: &str = concatcp!(WSDP_TYPE_DEVICE, " ", PUB_COMPUTER);
+pub const WSDP_TYPE_DEVICE_COMPUTER: &str = const_format!("{} {}", WSDP_TYPE_DEVICE, PUB_COMPUTER);
 
 // WSD_MCAST_GRP_V4: str = '239.255.255.250'
 pub const WSD_MCAST_GRP_V4: Ipv4Addr = Ipv4Addr::new(239, 255, 255, 250);
@@ -71,7 +71,7 @@ pub const WSD_MCAST_GRP_V4: Ipv4Addr = Ipv4Addr::new(239, 255, 255, 250);
 pub const WSD_MCAST_GRP_V6: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xc);
 
 // WSA_ANON: str = WSA_URI + '/role/anonymous'
-pub const WSA_ANON: &str = concatcp!(WSA_URI, "/role/anonymous");
+pub const WSA_ANON: &str = const_format!("{}{}", WSA_URI, "/role/anonymous");
 
 // WSA_DISCOVERY: str = 'urn:schemas-xmlsoap-org:ws:2005:04:discovery'
 pub const WSA_DISCOVERY: &str = "urn:schemas-xmlsoap-org:ws:2005:04:discovery";


### PR DESCRIPTION

`const_format -> konst 0.2.13:`

 ```
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/konst-0.2.19/src/ptr.rs:159:13
    |
159 |             core::mem::transmute::<*const T, Option<NonNull<T>>>(ptr),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `*const T` (pointer to `T`)
    = note: target type: `core::option::Option<core::ptr::NonNull<T>>` (size can vary because of <T as core::ptr::Pointee>::Metadata)
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/konst-0.2.19/src/ptr.rs:189:18
    |
189 |         unsafe { core::mem::transmute(ptr) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `*mut T` (pointer to `T`)
    = note: target type: `core::option::Option<core::ptr::NonNull<T>>` (size can vary because of <T as core::ptr::Pointee>::Metadata)

```