### PR TITLE
chore: explicitly wait for the miri tests to past in rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -375,6 +375,7 @@ jobs:
       - cargo-clippy-and-report
       - cargo-fmt
       - cargo-test-and-report
+      - cargo-test-and-report-miri
     if: |
       !cancelled()
     steps:


### PR DESCRIPTION
Before a failure here would flow up to ci.yml as part of the workflow
call, but that's not the contract we want locally
