### PR TITLE
test: parameterize the `XAddrs` port in the resolve-matches template

### DIFF
--- a/crates/wsdd-rs/src/test/resolve-matches-template.xml
+++ b/crates/wsdd-rs/src/test/resolve-matches-template.xml
@@ -20,7 +20,7 @@
                     <wsa:Address>{}</wsa:Address>
                 </wsa:EndpointReference>
                 <wsd:Types>wsdp:Device pub:Computer</wsd:Types>
-                <wsd:XAddrs>http://{}:5357/{}</wsd:XAddrs>
+                <wsd:XAddrs>http://{}:{}/{}</wsd:XAddrs>
                 <wsd:MetadataVersion>1</wsd:MetadataVersion>
             </wsd:ResolveMatch>
         </wsd:ResolveMatches>

--- a/crates/wsdd-rs/src/wsd/udp/client.rs
+++ b/crates/wsdd-rs/src/wsd/udp/client.rs
@@ -1340,7 +1340,8 @@ mod tests {
         let mut server = mockito::Server::new_with_opts_async(ServerOpts {
             // a host in IPv4 form ensures we bind to an IPv4 address
             host: "127.0.0.1",
-            port: 5357,
+            // random port
+            port: 0,
             assert_on_drop: true,
         })
         .await;
@@ -1380,6 +1381,7 @@ mod tests {
             0,
             host_config.uuid_as_device_uri,
             server.socket_address().ip(),
+            server.socket_address().port(),
             host_config.uuid
         );
 

--- a/crates/wsdd-rs/src/wsd/udp/host.rs
+++ b/crates/wsdd-rs/src/wsd/udp/host.rs
@@ -291,6 +291,7 @@ mod tests {
     use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
+    use crate::constants;
     use crate::network_address::NetworkAddress;
     use crate::network_interface::NetworkInterface;
     use crate::test_utils::xml::to_string_pretty;
@@ -435,6 +436,7 @@ mod tests {
             host_messages_built.load(Ordering::Relaxed) - 1,
             host_config.uuid_as_device_uri,
             host_ip,
+            constants::WSD_HTTP_PORT,
             host_config.uuid
         );
 


### PR DESCRIPTION
The template's `XAddrs` pointed at port 5357, so any test feeding it to the client had to bind its mock server to exactly that port. Only one test at a time can do that, which blocks parallel runs and any new test that needs its own server.