### PR TITLE
test: mock interface name resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +572,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fragile"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1091,6 +1106,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a6ceddfe3ce334925e96bf420fdb2dcee5bed6c632a168ece622676dadeaf8a"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cfe16fbe8a314aeec0b861ac24e60b1e123e97634bab045475b9d6a18416fd8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "mockito"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1369,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1825,6 +1892,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -2401,6 +2474,7 @@ dependencies = [
  "ipnet",
  "libc",
  "mimalloc",
+ "mockall",
  "mockito",
  "pin-project",
  "pretty_assertions",

--- a/crates/wsdd-rs/Cargo.toml
+++ b/crates/wsdd-rs/Cargo.toml
@@ -86,6 +86,7 @@ reqwest = { version = "=0.13.4", default-features = false, features = [
 ] }
 
 [dev-dependencies]
+mockall = "=0.15.0"
 mockito = "=1.7.2"
 pretty_assertions = { version = "=1.4.1", features = ["unstable"] }
 trybuild = "=1.0.120"

--- a/crates/wsdd-rs/src/network_handler.rs
+++ b/crates/wsdd-rs/src/network_handler.rs
@@ -25,7 +25,7 @@ use crate::config::Config;
 use crate::max_size_deque::MaxSizeDeque;
 use crate::multicast_handler::MulticastHandler;
 use crate::network_address::NetworkAddress;
-use crate::network_interface::{self, NetworkInterface};
+use crate::network_interface::{LibcInterfaceNameResolver, NetworkInterface, ResolveInterfaceName};
 use crate::wsd::device::{DeviceUri, WSDDiscoveredDevice};
 
 #[derive(Debug)]
@@ -66,7 +66,8 @@ pub enum Reason {
     ExcludedInterface,
 }
 
-pub struct NetworkHandler {
+pub struct NetworkHandler<R = LibcInterfaceNameResolver> {
+    resolver: R,
     active: AtomicBool,
     cancellation_token: CancellationToken,
     config: Arc<Config>,
@@ -92,7 +93,31 @@ impl NetworkHandler {
         start_tx: StartSender<()>,
         recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
     ) -> Self {
+        Self::with_resolver(
+            cancellation_token,
+            config,
+            command_rx,
+            start_tx,
+            recent_messages,
+            LibcInterfaceNameResolver,
+        )
+    }
+}
+
+impl<R> NetworkHandler<R>
+where
+    R: ResolveInterfaceName,
+{
+    fn with_resolver(
+        cancellation_token: CancellationToken,
+        config: &Arc<Config>,
+        command_rx: Receiver<Command>,
+        start_tx: StartSender<()>,
+        recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
+        resolver: R,
+    ) -> Self {
         Self {
+            resolver,
             active: AtomicBool::new(false),
             config: Arc::clone(config),
             cancellation_token,
@@ -262,7 +287,7 @@ impl NetworkHandler {
         let interface = match self.interfaces.entry(ifa_index) {
             Entry::Occupied(occupied_entry) => Arc::clone(occupied_entry.get()),
             Entry::Vacant(vacant_entry) => {
-                let if_name = match network_interface::if_indextoname(ifa_index) {
+                let if_name = match self.resolver.resolve(ifa_index) {
                     Ok(if_name) => if_name,
                     Err(error) => {
                         // the interface can vanish between the netlink event and this lookup
@@ -528,6 +553,7 @@ mod tests {
 
     use crate::max_size_deque::MaxSizeDeque;
     use crate::network_handler::{Command, NetworkHandler};
+    use crate::network_interface::MockResolveInterfaceName;
     use crate::test_utils::{build_config, find_first_non_lo_network_interface};
 
     #[tokio::test]
@@ -536,22 +562,29 @@ mod tests {
         let (command_tx, command_rx) = mpsc::channel(10);
         let (start_tx, mut start_rx) = watch::channel(());
 
-        let mut network_handler = NetworkHandler::new(
+        let mut resolver = MockResolveInterfaceName::new();
+
+        resolver
+            .expect_resolve()
+            .times(2)
+            .returning(|_| Err(std::io::Error::from_raw_os_error(libc::ENXIO)));
+
+        let mut network_handler = NetworkHandler::with_resolver(
             CancellationToken::new(),
             &config,
             command_rx,
             start_tx,
             Arc::new(RwLock::new(MaxSizeDeque::new(10))),
+            resolver,
         );
 
         let handle = tokio::spawn(async move { network_handler.process_commands().await });
 
-        // `u32::MAX` never resolves to an interface name
         command_tx
             .send(Command::NewAddress {
                 address: "192.0.2.1/24".parse().unwrap(),
                 scope: 0,
-                index: u32::MAX,
+                index: 7,
             })
             .await
             .unwrap();
@@ -560,7 +593,7 @@ mod tests {
             .send(Command::DeleteAddress {
                 address: "192.0.2.1/24".parse().unwrap(),
                 scope: 0,
-                index: u32::MAX,
+                index: 7,
             })
             .await
             .unwrap();
@@ -575,9 +608,44 @@ mod tests {
         assert_matches!(handle.await.unwrap(), Ok(()));
     }
 
+    #[test]
+    fn interface_lookup_caches_the_name() {
+        let config = Arc::new(build_config(Uuid::now_v7(), "1"));
+        let (_command_tx, command_rx) = mpsc::channel(1);
+        let (start_tx, _start_rx) = watch::channel(());
+
+        let mut resolver = MockResolveInterfaceName::new();
+
+        // the cache is insert-only, only the first lookup may resolve
+        resolver
+            .expect_resolve()
+            .times(1)
+            .returning(|_| Ok(Box::from("eth0")));
+
+        let mut network_handler = NetworkHandler::with_resolver(
+            CancellationToken::new(),
+            &config,
+            command_rx,
+            start_tx,
+            Arc::new(RwLock::new(MaxSizeDeque::new(10))),
+            resolver,
+        );
+
+        let first = network_handler.add_interface(0, 2).unwrap();
+
+        assert_eq!(first.name(), "eth0");
+
+        let second = network_handler.add_interface(0, 2).unwrap();
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "a second lookup returns the same entry"
+        );
+    }
+
     #[cfg_attr(not(miri), test)]
     #[cfg_attr(miri, expect(unused, reason = "This test doesn't work with Miri"))]
-    fn interface_lookup_resolves_the_real_name_and_caches_it() {
+    fn interface_lookup_resolves_the_real_name() {
         let config = Arc::new(build_config(Uuid::now_v7(), "1"));
         let (_command_tx, command_rx) = mpsc::channel(1);
         let (start_tx, _start_rx) = watch::channel(());
@@ -592,15 +660,8 @@ mod tests {
 
         let (name, index) = find_first_non_lo_network_interface().unwrap();
 
-        let first = network_handler.add_interface(0, index).unwrap();
+        let interface = network_handler.add_interface(0, index).unwrap();
 
-        assert_eq!(first.name(), &*name);
-
-        let second = network_handler.add_interface(0, index).unwrap();
-
-        assert!(
-            Arc::ptr_eq(&first, &second),
-            "the cache is insert-only, a second lookup returns the same entry"
-        );
+        assert_eq!(interface.name(), &*name);
     }
 }

--- a/crates/wsdd-rs/src/network_interface.rs
+++ b/crates/wsdd-rs/src/network_interface.rs
@@ -71,31 +71,33 @@ pub fn if_nametoindex(name: &str) -> Result<u32, std::io::Error> {
 }
 
 pub fn if_indextoname(index: u32) -> Result<Box<str>, std::io::Error> {
-    #[cfg(miri)]
-    {
-        // Miri cannot call `if_indextoname`, behave as if no interface exists
-        let _ = index;
+    let mut buffer = vec![0_u8; IF_NAMESIZE];
 
-        Err(Error::from_raw_os_error(libc::ENXIO))
+    // SAFETY: libc call
+    let result = unsafe { libc::if_indextoname(index, buffer.as_mut_ptr().cast()) };
+
+    if result.is_null() {
+        return Err(Error::last_os_error());
     }
 
-    #[cfg(not(miri))]
-    {
-        let mut buffer = vec![0_u8; IF_NAMESIZE];
+    let ifname = CStr::from_bytes_until_nul(&buffer)
+        .expect("We used oversized buffer, so not finding a null is impossible")
+        .to_str()
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
 
-        // SAFETY: libc call
-        let result = unsafe { libc::if_indextoname(index, buffer.as_mut_ptr().cast()) };
+    Ok(String::from(ifname).into_boxed_str())
+}
 
-        if result.is_null() {
-            return Err(Error::last_os_error());
-        }
+#[cfg_attr(test, mockall::automock)]
+pub trait ResolveInterfaceName {
+    fn resolve(&self, index: u32) -> Result<Box<str>, std::io::Error>;
+}
 
-        let ifname = CStr::from_bytes_until_nul(&buffer)
-            .expect("We used oversized buffer, so not finding a null is impossible")
-            .to_str()
-            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+pub struct LibcInterfaceNameResolver;
 
-        Ok(String::from(ifname).into_boxed_str())
+impl ResolveInterfaceName for LibcInterfaceNameResolver {
+    fn resolve(&self, index: u32) -> Result<Box<str>, std::io::Error> {
+        if_indextoname(index)
     }
 }
 


### PR DESCRIPTION
`if_indextoname` cannot run under Miri, which forced a `cfg(miri)` stub inside the production function. 

The cache test needed `getifaddrs` to find a real interface, so it could not run under Miri at all. Name resolution now goes through a `ResolveInterfaceName` trait that tests replace with a `mockall` mock. The stub is gone and both tests run everywhere.

A separate test, excluded from Miri, calls the real `LibcInterfaceNameResolver` so the actual `libc` path stays covered.
