### PR TITLE
fix: honor IP addresses given to `--interface`

### DIFF
--- a/crates/wsdd-rs/src/cli.rs
+++ b/crates/wsdd-rs/src/cli.rs
@@ -6,12 +6,14 @@ use std::time::Duration;
 
 use clap::{ArgAction, Parser};
 use color_eyre::eyre;
+use color_eyre::eyre::WrapErr as _;
 use tracing::{Level, event};
 use uuid::Uuid;
 use uuid::fmt::Urn;
 
-use crate::config::{BindTo, Config, PortOrSocket};
+use crate::config::{BindTo, Config, InterfaceFilter, PortOrSocket};
 use crate::ffi::listen_fds;
+use crate::network_interface::DevName;
 use crate::security::parse_userspec;
 use crate::wsd::device::DeviceUri;
 
@@ -127,24 +129,18 @@ where
     // TODO: How do we return a specific error (e.g. 3 for the user spec's value parser) when an error occurs?
     let args = CliArgs::try_parse_from(from)?;
 
-    let interfaces: Vec<Box<str>> = if args.interface.is_empty() {
+    let interfaces: Vec<InterfaceFilter> = if args.interface.is_empty() {
         event!(Level::WARN, "no interface given, using all interfaces");
 
         vec![]
     } else {
         args.interface
             .into_iter()
-            .map(String::into_boxed_str)
-            .inspect(|interface| {
-                if interface_value_can_never_match(interface) {
-                    event!(
-                        Level::WARN,
-                        %interface,
-                        "interface value can never match, alias labels like `eth0:0` are not supported yet, use the interface name or address"
-                    );
-                }
-            })
-            .collect()
+            .map(to_interface_filter)
+            .collect::<Result<_, _>>()
+            .wrap_err(
+                "invalid --interface value, alias labels like `eth0:0` are not supported yet",
+            )?
     };
 
     let hostname = if let Some(hostname) = args.hostname {
@@ -268,10 +264,12 @@ fn sequence_id() -> Urn {
     }
 }
 
-/// Interface names cannot contain `:` (see the kernel's `dev_valid_name`), so a value with a
-/// colon that is not an IPv6 address can never match an interface or an address.
-fn interface_value_can_never_match(value: &str) -> bool {
-    value.contains(':') && value.parse::<IpAddr>().is_err()
+fn to_interface_filter(value: String) -> Result<InterfaceFilter, eyre::Report> {
+    if let Ok(address) = value.parse::<IpAddr>() {
+        return Ok(InterfaceFilter::Address(address));
+    }
+
+    DevName::try_from(value.into_boxed_str()).map(InterfaceFilter::Name)
 }
 
 fn to_listen(listen: &str) -> Result<PortOrSocket, String> {
@@ -346,13 +344,15 @@ fn get_uuid_from_machine() -> Result<Uuid, eyre::Report> {
 
 #[cfg(test)]
 mod tests {
+    use std::net::IpAddr;
     use std::path::Path;
 
     use pretty_assertions::{assert_eq, assert_matches};
     use tracing::Level;
 
-    use crate::cli::{interface_value_can_never_match, parse_cli_from, to_listen};
-    use crate::config::PortOrSocket;
+    use crate::cli::{parse_cli_from, to_interface_filter, to_listen};
+    use crate::config::{InterfaceFilter, PortOrSocket};
+    use crate::network_interface::DevName;
 
     #[test]
     fn interfaces() {
@@ -360,24 +360,53 @@ mod tests {
             parse_cli_from(["wsdd-rs", "--interface", "eth0", "--interface", "eth1"]).unwrap();
 
         assert_eq!(
-            config
-                .interfaces
-                .iter()
-                .map(AsRef::as_ref)
-                .collect::<Vec<_>>(),
-            &["eth0", "eth1"]
+            config.interfaces,
+            &[
+                InterfaceFilter::Name(DevName::try_from(Box::from("eth0")).unwrap()),
+                InterfaceFilter::Name(DevName::try_from(Box::from("eth1")).unwrap())
+            ]
         );
     }
 
     #[test]
-    fn interface_values_with_colons_can_never_match() {
-        assert!(interface_value_can_never_match("eth0:0"));
-        assert!(interface_value_can_never_match("fe80::1%eth0"));
+    fn interface_values_classify_as_name_or_address() {
+        assert_matches!(to_interface_filter("eth0".into()), Ok(InterfaceFilter::Name(n)) if n.as_ref() == "eth0");
+        assert_matches!(
+            to_interface_filter("eth0.100".into()),
+            Ok(InterfaceFilter::Name(_))
+        );
+        assert_matches!(
+            to_interface_filter("a".repeat(15)),
+            Ok(InterfaceFilter::Name(_))
+        );
+        assert_matches!(
+            to_interface_filter("192.168.1.5".into()),
+            Ok(InterfaceFilter::Address(IpAddr::V4(_)))
+        );
+        assert_matches!(
+            to_interface_filter("fe80::1".into()),
+            Ok(InterfaceFilter::Address(IpAddr::V6(_)))
+        );
+    }
 
-        assert!(!interface_value_can_never_match("eth0"));
-        assert!(!interface_value_can_never_match("eth0.100"));
-        assert!(!interface_value_can_never_match("fe80::1"));
-        assert!(!interface_value_can_never_match("192.168.1.5"));
+    #[test]
+    fn invalid_interface_values_are_rejected() {
+        assert_matches!(to_interface_filter("eth0:0".into()), Err(_));
+        assert_matches!(to_interface_filter("fe80::1%eth0".into()), Err(_));
+        assert_matches!(to_interface_filter(String::new()), Err(_));
+        assert_matches!(to_interface_filter(".".into()), Err(_));
+        assert_matches!(to_interface_filter("..".into()), Err(_));
+        assert_matches!(to_interface_filter("eth 0".into()), Err(_));
+        assert_matches!(to_interface_filter("eth/0".into()), Err(_));
+        assert_matches!(to_interface_filter("a".repeat(16)), Err(_));
+    }
+
+    #[test]
+    fn any_invalid_interface_value_is_an_error() {
+        // valid values do not mask the invalid one
+        let result = parse_cli_from(["wsdd-rs", "--interface", "eth0", "--interface", "eth0:0"]);
+
+        assert_matches!(result, Err(_));
     }
 
     #[test]

--- a/crates/wsdd-rs/src/config.rs
+++ b/crates/wsdd-rs/src/config.rs
@@ -1,3 +1,4 @@
+use std::net::IpAddr;
 use std::os::fd::RawFd;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -5,12 +6,13 @@ use std::time::Duration;
 use tracing::{Level, event};
 use uuid::Uuid;
 
+use crate::network_interface::DevName;
 use crate::wsd::device::DeviceUri;
 
 #[expect(clippy::struct_excessive_bools, reason = "Main config")]
 #[derive(Debug)]
 pub struct Config {
-    pub interfaces: Vec<Box<str>>,
+    pub interfaces: Vec<InterfaceFilter>,
     pub hoplimit: u8,
     pub uuid: Uuid,
     pub uuid_as_device_uri: DeviceUri,
@@ -39,6 +41,12 @@ pub struct Config {
     pub wsd_instance_id: Box<str>,
     pub sequence_id: Box<str>,
     pub bind_to: BindTo,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum InterfaceFilter {
+    Name(DevName),
+    Address(IpAddr),
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/crates/wsdd-rs/src/network_handler.rs
+++ b/crates/wsdd-rs/src/network_handler.rs
@@ -21,7 +21,7 @@ use tokio_util::task::TaskTracker;
 use tracing::{Level, event};
 use uuid::fmt::Urn;
 
-use crate::config::Config;
+use crate::config::{Config, InterfaceFilter};
 use crate::max_size_deque::MaxSizeDeque;
 use crate::multicast_handler::MulticastHandler;
 use crate::network_address::NetworkAddress;
@@ -334,18 +334,12 @@ where
             return Err(Reason::AddressNotMulticastable);
         }
 
-        // Use interface only if it's in the list of user-provided interface names
+        // Use the address only if it matches one of the user-provided filters
         if !self.config.interfaces.is_empty()
-            && !self
-                .config
-                .interfaces
-                .iter()
-                .any(|i| &**i == address.interface.name())
-            && !self
-                .config
-                .interfaces
-                .iter()
-                .any(|i| **i == address.address.to_string())
+            && !self.config.interfaces.iter().any(|filter| match *filter {
+                InterfaceFilter::Name(ref name) => name.as_ref() == address.interface.name(),
+                InterfaceFilter::Address(ip) => ip == address.address.addr(),
+            })
         {
             return Err(Reason::ExcludedInterface);
         }
@@ -545,16 +539,33 @@ where
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::atomic::Ordering;
 
     use pretty_assertions::{assert_eq, assert_matches};
     use tokio::sync::{RwLock, mpsc, watch};
     use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
+    use crate::config::{Config, InterfaceFilter};
     use crate::max_size_deque::MaxSizeDeque;
-    use crate::network_handler::{Command, NetworkHandler};
-    use crate::network_interface::MockResolveInterfaceName;
+    use crate::network_address::NetworkAddress;
+    use crate::network_handler::{Command, NetworkHandler, Reason};
+    use crate::network_interface::{DevName, MockResolveInterfaceName, NetworkInterface};
     use crate::test_utils::{build_config, find_first_non_lo_network_interface};
+
+    fn build_network_handler(config: Config) -> NetworkHandler<MockResolveInterfaceName> {
+        let (_command_tx, command_rx) = mpsc::channel(1);
+        let (start_tx, _start_rx) = watch::channel(());
+
+        NetworkHandler::with_resolver(
+            CancellationToken::new(),
+            &Arc::new(config),
+            command_rx,
+            start_tx,
+            Arc::new(RwLock::new(MaxSizeDeque::new(10))),
+            MockResolveInterfaceName::new(),
+        )
+    }
 
     #[tokio::test]
     async fn failed_interface_lookup_does_not_stop_command_processing() {
@@ -663,5 +674,49 @@ mod tests {
         let interface = network_handler.add_interface(0, index).unwrap();
 
         assert_eq!(interface.name(), &*name);
+    }
+
+    #[test]
+    fn interface_filter_matches_by_name() {
+        let mut config = build_config(Uuid::now_v7(), "1");
+        config.interfaces = vec![InterfaceFilter::Name(
+            DevName::try_from(Box::from("eth0")).unwrap(),
+        )];
+
+        let network_handler = build_network_handler(config);
+        network_handler.active.store(true, Ordering::Relaxed);
+
+        let eth0 = Arc::new(NetworkInterface::new_with_index("eth0", 0, 2));
+        let eth1 = Arc::new(NetworkInterface::new_with_index("eth1", 0, 3));
+
+        let on_eth0 = NetworkAddress::new("192.168.100.5/24".parse().unwrap(), eth0);
+        let on_eth1 = NetworkAddress::new("192.168.200.5/24".parse().unwrap(), eth1);
+
+        assert_matches!(network_handler.is_address_handled(&on_eth0), Ok(()));
+        assert_matches!(
+            network_handler.is_address_handled(&on_eth1),
+            Err(Reason::ExcludedInterface)
+        );
+    }
+
+    #[test]
+    fn interface_filter_matches_by_address() {
+        let mut config = build_config(Uuid::now_v7(), "1");
+        config.interfaces = vec![InterfaceFilter::Address("192.168.100.5".parse().unwrap())];
+
+        let network_handler = build_network_handler(config);
+        network_handler.active.store(true, Ordering::Relaxed);
+
+        let interface = Arc::new(NetworkInterface::new_with_index("eth0", 0, 2));
+
+        let matching =
+            NetworkAddress::new("192.168.100.5/24".parse().unwrap(), Arc::clone(&interface));
+        let other = NetworkAddress::new("192.168.100.6/24".parse().unwrap(), interface);
+
+        assert_matches!(network_handler.is_address_handled(&matching), Ok(()));
+        assert_matches!(
+            network_handler.is_address_handled(&other),
+            Err(Reason::ExcludedInterface)
+        );
     }
 }

--- a/crates/wsdd-rs/src/network_interface.rs
+++ b/crates/wsdd-rs/src/network_interface.rs
@@ -88,6 +88,39 @@ pub fn if_indextoname(index: u32) -> Result<Box<str>, std::io::Error> {
     Ok(String::from(ifname).into_boxed_str())
 }
 
+#[derive(Debug, Eq, PartialEq)]
+pub struct DevName(Box<str>);
+
+impl TryFrom<Box<str>> for DevName {
+    type Error = eyre::Report;
+
+    /// Follows the kernel's `dev_valid_name`.
+    fn try_from(value: Box<str>) -> Result<Self, Self::Error> {
+        let valid = !value.is_empty()
+            && value.len() < libc::IFNAMSIZ
+            && &*value != "."
+            && &*value != ".."
+            && !value
+                .chars()
+                .any(|c| c == '/' || c == ':' || c.is_whitespace());
+
+        if valid {
+            Ok(Self(value))
+        } else {
+            Err(eyre::Report::msg(format!(
+                "`{}` is not a valid interface name",
+                value
+            )))
+        }
+    }
+}
+
+impl AsRef<str> for DevName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 #[cfg_attr(test, mockall::automock)]
 pub trait ResolveInterfaceName {
     fn resolve(&self, index: u32) -> Result<Box<str>, std::io::Error>;

--- a/project-words.txt
+++ b/project-words.txt
@@ -88,6 +88,7 @@ ifas
 IFINFO
 IFLIST
 ifname
+IFNAMSIZ
 IHHII
 implictely
 indextoname


### PR DESCRIPTION
Filtering by address never worked. The comparison used `IpNet::to_string()`, which always includes the prefix (`192.168.100.5/24`), so no user-supplied address could ever be equal.

`--interface` values are now parsed once at CLI time into `InterfaceFilter::Name` or `InterfaceFilter::Address`, and `is_address_handled` matches on the variant.
Comparing `IpAddr` values also accepts non-canonical IPv6 spellings like `FE80::1`.

Upstream compares strings against `inet_ntop` output and silently fails on those.

`InterfaceFilter::Name` holds a `DevName`, whose `TryFrom` enforces the kernel's `dev_valid_name` rules. Any other value is a startup error, like every other flag. We deliberately do not fall back to all interfaces.

`--interface` is the flag that keeps wsdd off specific networks, so a typo like `eth0:0` must refuse to start, not expose the host more broadly than configured.
