### PR TITLE
fix: accept any URI as `MessageID`

### DIFF
--- a/crates/wsdd-rs/src/main.rs
+++ b/crates/wsdd-rs/src/main.rs
@@ -49,7 +49,6 @@ use tracing::{Level, event};
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{EnvFilter, Layer as _};
-use uuid::fmt::Urn;
 
 use crate::address_monitor::create_address_monitor;
 use crate::build_env::get_build_env;
@@ -60,6 +59,7 @@ use crate::max_size_deque::MaxSizeDeque;
 use crate::network_handler::{Command, NetworkHandler};
 use crate::security::{chroot, drop_privileges};
 use crate::shutdown::Shutdown;
+use crate::soap::MessageId;
 use crate::utils::task::{flatten_shutdown_handle, spawn_with_name};
 
 #[cfg_attr(not(miri), global_allocator)]
@@ -231,7 +231,7 @@ async fn start_tasks() -> Shutdown {
         return shutdown;
     }
 
-    let recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>> =
+    let recent_messages: Arc<RwLock<MaxSizeDeque<MessageId>>> =
         Arc::new(RwLock::new(MaxSizeDeque::new(WSD_MAX_KNOWN_MESSAGES)));
 
     // shutdown broadcast: every task watches this token (or a child of it) to know

--- a/crates/wsdd-rs/src/message_receiver.rs
+++ b/crates/wsdd-rs/src/message_receiver.rs
@@ -6,14 +6,13 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{Level, event};
-use uuid::fmt::Urn;
 
 use crate::constants;
 use crate::max_size_deque::MaxSizeDeque;
 use crate::multicast_handler::{IncomingClientMessage, IncomingHostMessage};
 use crate::network_address::NetworkAddress;
-use crate::soap::WSDMessage;
 use crate::soap::parser::MessageHandler;
+use crate::soap::{MessageId, WSDMessage};
 use crate::udp_socket_with_addr::UdpSocketWithAddr;
 use crate::utils::task::spawn_with_name;
 
@@ -31,7 +30,7 @@ impl MessageReceiver {
     pub fn new(
         cancellation_token: CancellationToken,
         network_address: NetworkAddress,
-        recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
+        recent_messages: Arc<RwLock<MaxSizeDeque<MessageId>>>,
         socket: Arc<UdpSocketWithAddr>,
     ) -> Self {
         let listeners = Arc::new(RwLock::const_new(ClientHostListener {
@@ -100,7 +99,7 @@ async fn socket_rx_forever(
     cancellation_token: CancellationToken,
     network_address: NetworkAddress,
     listeners: Arc<RwLock<ClientHostListener>>,
-    recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
+    recent_messages: Arc<RwLock<MaxSizeDeque<MessageId>>>,
     socket: Arc<UdpSocketWithAddr>,
 ) {
     let message_handler = MessageHandler::new(network_address, recent_messages);

--- a/crates/wsdd-rs/src/multicast_handler.rs
+++ b/crates/wsdd-rs/src/multicast_handler.rs
@@ -15,7 +15,6 @@ use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::{Level, event};
-use uuid::fmt::Urn;
 
 use crate::config::Config;
 use crate::constants;
@@ -24,7 +23,9 @@ use crate::message_receiver::MessageReceiver;
 use crate::network_address::NetworkAddress;
 use crate::network_interface::NetworkInterface;
 use crate::soap::parser::Header;
-use crate::soap::{ClientMessage, HostMessage, MessageType, MulticastMessage, UnicastMessage};
+use crate::soap::{
+    ClientMessage, HostMessage, MessageId, MessageType, MulticastMessage, UnicastMessage,
+};
 use crate::udp_address::UdpAddress;
 use crate::udp_socket_with_addr::UdpSocketWithAddr;
 use crate::url_ip_addr::UrlIpAddr;
@@ -43,7 +44,7 @@ pub struct MulticastHandler {
     /// Shared reference to all discovered devices.
     devices: Arc<RwLock<HashMap<DeviceUri, WSDDiscoveredDevice>>>,
 
-    recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
+    recent_messages: Arc<RwLock<MaxSizeDeque<MessageId>>>,
 
     /// Shared reference for global message counter.
     messages_built: Arc<AtomicU64>,
@@ -99,7 +100,7 @@ impl MulticastHandler {
         cancellation_token: CancellationToken,
         config: Arc<Config>,
         devices: Arc<RwLock<HashMap<DeviceUri, WSDDiscoveredDevice>>>,
-        recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
+        recent_messages: Arc<RwLock<MaxSizeDeque<MessageId>>>,
     ) -> Result<Self, eyre::Report> {
         let domain = match network_address.address {
             IpNet::V4(_) => Domain::IPV4,

--- a/crates/wsdd-rs/src/network_handler.rs
+++ b/crates/wsdd-rs/src/network_handler.rs
@@ -19,13 +19,13 @@ use tokio::sync::watch::Sender as StartSender;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::{Level, event};
-use uuid::fmt::Urn;
 
 use crate::config::{Config, InterfaceFilter};
 use crate::max_size_deque::MaxSizeDeque;
 use crate::multicast_handler::MulticastHandler;
 use crate::network_address::NetworkAddress;
 use crate::network_interface::{LibcInterfaceNameResolver, NetworkInterface, ResolveInterfaceName};
+use crate::soap::MessageId;
 use crate::wsd::device::{DeviceUri, WSDDiscoveredDevice};
 
 #[derive(Debug)]
@@ -76,7 +76,7 @@ pub struct NetworkHandler<R = LibcInterfaceNameResolver> {
     multicast_handlers: Vec<MulticastHandler>,
     command_rx: Receiver<Command>,
     start_tx: StartSender<()>,
-    recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
+    recent_messages: Arc<RwLock<MaxSizeDeque<MessageId>>>,
 }
 
 #[derive(Debug, Error)]
@@ -91,7 +91,7 @@ impl NetworkHandler {
         config: &Arc<Config>,
         command_rx: Receiver<Command>,
         start_tx: StartSender<()>,
-        recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
+        recent_messages: Arc<RwLock<MaxSizeDeque<MessageId>>>,
     ) -> Self {
         Self::with_resolver(
             cancellation_token,
@@ -113,7 +113,7 @@ where
         config: &Arc<Config>,
         command_rx: Receiver<Command>,
         start_tx: StartSender<()>,
-        recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
+        recent_messages: Arc<RwLock<MaxSizeDeque<MessageId>>>,
         resolver: R,
     ) -> Self {
         Self {

--- a/crates/wsdd-rs/src/soap.rs
+++ b/crates/wsdd-rs/src/soap.rs
@@ -1,4 +1,5 @@
 use axum::response::IntoResponse;
+use uuid::fmt::Urn;
 
 use crate::soap::parser::bye::Bye;
 use crate::soap::parser::get::Get;
@@ -10,6 +11,37 @@ use crate::soap::parser::resolve_match::ResolveMatch;
 
 pub mod builder;
 pub mod parser;
+
+/// An incoming `[message id]` or `[relates to]` value.
+///
+/// WS-Addressing declares these as `xs:anyURI`, so they are opaque and compared
+/// byte-wise, never parsed. Replies echo them verbatim.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MessageId(Box<str>);
+
+impl MessageId {
+    pub fn new(value: Box<str>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Urn> for MessageId {
+    fn from(urn: Urn) -> Self {
+        Self(urn.to_string().into_boxed_str())
+    }
+}
+
+impl AsRef<str> for MessageId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for MessageId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 pub trait MessageType {
     fn message_type(&self) -> &str;

--- a/crates/wsdd-rs/src/soap.rs
+++ b/crates/wsdd-rs/src/soap.rs
@@ -12,10 +12,7 @@ use crate::soap::parser::resolve_match::ResolveMatch;
 pub mod builder;
 pub mod parser;
 
-/// An incoming `[message id]` or `[relates to]` value.
-///
-/// WS-Addressing declares these as `xs:anyURI`, so they are opaque and compared
-/// byte-wise, never parsed. Replies echo them verbatim.
+/// An incoming `[message id]` or `[relates to]`, an opaque `xs:anyURI` compared byte-wise.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MessageId(Box<str>);
 

--- a/crates/wsdd-rs/src/soap/builder.rs
+++ b/crates/wsdd-rs/src/soap/builder.rs
@@ -26,7 +26,7 @@ use crate::soap::builder::header::WriteExtraHeaders;
 use crate::soap::builder::header::app_sequence::AppSequence;
 use crate::soap::builder::header::none::NoExtraHeaders;
 use crate::soap::builder::header::reply_to_from::ReplyToFrom;
-use crate::soap::{MulticastMessage, UnicastMessage};
+use crate::soap::{MessageId, MulticastMessage, UnicastMessage};
 use crate::wsd::device::DeviceUri;
 
 pub struct Builder<'config> {
@@ -61,7 +61,7 @@ impl<'config> Builder<'config> {
         &mut self,
         to_addr: D,
         action: &str,
-        relates_to: Option<Urn>,
+        relates_to: Option<&MessageId>,
         extra_headers: H,
         body: B,
     ) -> Result<(W, Urn), xml::writer::Error>
@@ -100,7 +100,7 @@ impl<'config> Builder<'config> {
         &mut self,
         to_addr: &D,
         action: &str,
-        relates_to: Option<Urn>,
+        relates_to: Option<&MessageId>,
         extra_headers: H,
         body: B,
     ) -> Result<(W, Urn), xml::writer::Error>
@@ -151,9 +151,8 @@ impl<'config> Builder<'config> {
 
         if let Some(relates_to) = relates_to {
             header_and_body.write(XmlEvent::start_element("wsa:RelatesTo"))?;
-            header_and_body.write(XmlEvent::Characters(
-                relates_to.encode_lower(&mut Uuid::encode_buffer()),
-            ))?;
+            // `[relates to]` MUST be the value of the incoming `[message id]`, echo it verbatim
+            header_and_body.write(XmlEvent::Characters(relates_to.as_ref()))?;
             header_and_body.write(XmlEvent::end_element())?;
         }
 
@@ -257,7 +256,7 @@ impl<'config> Builder<'config> {
         config: &Config,
         address: IpAddr,
         messages_built: &AtomicU64,
-        relates_to: Urn,
+        relates_to: &MessageId,
     ) -> Result<UnicastMessage, xml::writer::Error> {
         let mut builder = Builder::new(config);
 
@@ -279,7 +278,7 @@ impl<'config> Builder<'config> {
     pub fn build_probe_matches(
         config: &Config,
         messages_built: &AtomicU64,
-        relates_to: Urn,
+        relates_to: &MessageId,
     ) -> Result<UnicastMessage, xml::writer::Error> {
         let mut builder = Builder::new(config);
 
@@ -314,7 +313,7 @@ impl<'config> Builder<'config> {
 
     pub fn build_get_response(
         config: &Config,
-        relates_to: Urn,
+        relates_to: &MessageId,
     ) -> Result<UnicastMessage, xml::writer::Error> {
         let mut builder = Builder::new(config);
 

--- a/crates/wsdd-rs/src/soap/parser.rs
+++ b/crates/wsdd-rs/src/soap/parser.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{Level, event};
-use uuid::fmt::Urn;
 use xml::ParserConfig;
 use xml::reader::XmlEvent;
 
@@ -24,20 +23,20 @@ use crate::max_size_deque::MaxSizeDeque;
 use crate::network_address::NetworkAddress;
 use crate::network_interface::NetworkInterface;
 use crate::soap::parser::get::Get;
-use crate::soap::{self, WSDMessage};
+use crate::soap::{self, MessageId, WSDMessage};
 use crate::wsd::device::DeviceUri;
 use crate::xml::{TextReadError, XmlError, XmlReader, read_text};
 
 pub struct MessageHandler {
     network_address: NetworkAddress,
-    recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
+    recent_messages: Arc<RwLock<MaxSizeDeque<MessageId>>>,
 }
 
 pub struct Header {
     pub to: Option<DeviceUri>,
     pub action: Box<str>,
-    pub message_id: Urn,
-    pub relates_to: Option<Urn>,
+    pub message_id: MessageId,
+    pub relates_to: Option<MessageId>,
 }
 
 #[derive(Error, Debug)]
@@ -48,10 +47,6 @@ pub enum HeaderParsingError {
     MissingMessageId,
     #[error("Missing Action")]
     MissingAction,
-    #[error("Invalid Message Id: {}", .0)]
-    InvalidMessageId(uuid::Error),
-    #[error("Invalid Relates To: {}", .0)]
-    InvalidRelatesTo(uuid::Error),
 }
 
 impl From<xml::reader::Error> for HeaderParsingError {
@@ -282,7 +277,7 @@ pub fn deconstruct_http_message(raw: &[u8]) -> Result<(Header, WSDMessage), Mess
 impl MessageHandler {
     pub fn new(
         network_address: NetworkAddress,
-        recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
+        recent_messages: Arc<RwLock<MaxSizeDeque<MessageId>>>,
     ) -> Self {
         Self {
             network_address,
@@ -299,7 +294,7 @@ impl MessageHandler {
         let (header, has_body, reader) = deconstruct_raw(raw)?;
 
         // check for duplicates
-        if self.is_duplicated_msg(header.message_id).await {
+        if self.is_duplicated_msg(&header.message_id).await {
             event!(
                 Level::DEBUG,
                 message_id = %header.message_id,
@@ -324,21 +319,21 @@ impl MessageHandler {
     /// Implements SOAP-over-UDP Appendix II Item 2
     /// Deduplicates best-effort: read lock filters most repeats cheaply, then a write
     /// lock inserts the ID if it is still absent. The unlocked gap means a rapid burst
-    /// can insert and evict the same `Urn` before our write guard runs, so some
+    /// can insert and evict the same id before our write guard runs, so some
     /// in-flight duplicates may be reprocessed, but we avoid taking a write lock for
     /// every message.
-    pub async fn is_duplicated_msg(&self, message_id: Urn) -> bool {
+    pub async fn is_duplicated_msg(&self, message_id: &MessageId) -> bool {
         {
             let read_lock = self.recent_messages.read().await;
 
-            if read_lock.contains(&message_id) {
+            if read_lock.contains(message_id) {
                 return true;
             }
         }
 
         let mut write_lock = self.recent_messages.write().await;
 
-        if write_lock.push_back(message_id) {
+        if write_lock.push_back(message_id.clone()) {
             // the queue did NOT have the message_id, so it's a new message
             false
         } else {
@@ -381,24 +376,12 @@ where
                         action = read_text(reader)?.map(String::into_boxed_str);
                     },
                     "MessageID" => {
-                        let m_id = read_text(reader)?
-                            .map(|m_id| {
-                                m_id.parse::<Urn>()
-                                    .map_err(HeaderParsingError::InvalidMessageId)
-                            })
-                            .transpose()?;
-
-                        message_id = m_id;
+                        message_id =
+                            read_text(reader)?.map(|m_id| MessageId::new(m_id.into_boxed_str()));
                     },
                     "RelatesTo" => {
-                        let r_to = read_text(reader)?
-                            .map(|r_to| {
-                                r_to.parse::<Urn>()
-                                    .map_err(HeaderParsingError::InvalidRelatesTo)
-                            })
-                            .transpose()?;
-
-                        relates_to = r_to;
+                        relates_to =
+                            read_text(reader)?.map(|r_to| MessageId::new(r_to.into_boxed_str()));
                     },
                     _ => {
                         // Not a match, continue
@@ -444,11 +427,11 @@ mod tests {
     use tokio::sync::RwLock;
     use tokio::time::{Duration, timeout};
     use uuid::Uuid;
-    use uuid::fmt::Urn;
 
     use crate::max_size_deque::MaxSizeDeque;
     use crate::network_address::NetworkAddress;
     use crate::network_interface::NetworkInterface;
+    use crate::soap::MessageId;
     use crate::soap::parser::MessageHandler;
 
     fn handler_for_tests(history: usize) -> MessageHandler {
@@ -464,11 +447,11 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn is_duplicated_msg_drops_read_lock_before_waiting_for_write_lock() {
         let handler = handler_for_tests(8);
-        let message_id = Urn::from_uuid(Uuid::now_v7());
+        let message_id = MessageId::from(Uuid::now_v7().urn());
 
         let first_hit = timeout(
             Duration::from_millis(100),
-            handler.is_duplicated_msg(message_id),
+            handler.is_duplicated_msg(&message_id),
         )
         .await
         .expect("read guard must be released before awaiting a write guard");
@@ -478,7 +461,7 @@ mod tests {
             "first observation of a message id should be reported as new"
         );
 
-        let second_hit = handler.is_duplicated_msg(message_id).await;
+        let second_hit = handler.is_duplicated_msg(&message_id).await;
 
         assert!(
             second_hit,

--- a/crates/wsdd-rs/src/test/get-response-samsung-printer.xml
+++ b/crates/wsdd-rs/src/test/get-response-samsung-printer.xml
@@ -12,8 +12,8 @@
     <soap:Header>
         <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
         <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</wsa:Action>
-        <wsa:MessageID>urn:uuid:{}</wsa:MessageID>
-        <wsa:RelatesTo RelationshipType="wsa:Reply">urn:uuid:{}</wsa:RelatesTo>
+        <wsa:MessageID>{}</wsa:MessageID>
+        <wsa:RelatesTo RelationshipType="wsa:Reply">{}</wsa:RelatesTo>
     </soap:Header>
     <soap:Body>
         <wsx:Metadata>

--- a/crates/wsdd-rs/src/test/get-response-synology.xml
+++ b/crates/wsdd-rs/src/test/get-response-synology.xml
@@ -11,8 +11,8 @@
     <soap:Header>
         <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
         <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</wsa:Action>
-        <wsa:MessageID>urn:uuid:{}</wsa:MessageID>
-        <wsa:RelatesTo>urn:uuid:{}</wsa:RelatesTo>
+        <wsa:MessageID>{}</wsa:MessageID>
+        <wsa:RelatesTo>{}</wsa:RelatesTo>
     </soap:Header>
     <soap:Body>
         <wsx:Metadata>

--- a/crates/wsdd-rs/src/test/get-response-template.xml
+++ b/crates/wsdd-rs/src/test/get-response-template.xml
@@ -11,7 +11,7 @@
         <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
         <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</wsa:Action>
         <wsa:MessageID>urn:uuid:{}</wsa:MessageID>
-        <wsa:RelatesTo>urn:uuid:{}</wsa:RelatesTo>
+        <wsa:RelatesTo>{}</wsa:RelatesTo>
     </soap:Header>
     <soap:Body>
         <wsx:Metadata>

--- a/crates/wsdd-rs/src/test/get-response-windows.xml
+++ b/crates/wsdd-rs/src/test/get-response-windows.xml
@@ -10,8 +10,8 @@
     <soap:Header>
         <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
         <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/GetResponse</wsa:Action>
-        <wsa:MessageID>urn:uuid:{}</wsa:MessageID>
-        <wsa:RelatesTo>urn:uuid:{}</wsa:RelatesTo>
+        <wsa:MessageID>{}</wsa:MessageID>
+        <wsa:RelatesTo>{}</wsa:RelatesTo>
     </soap:Header>
     <soap:Body>
         <wsx:Metadata>

--- a/crates/wsdd-rs/src/test/probe-matches-with-xaddrs-template.xml
+++ b/crates/wsdd-rs/src/test/probe-matches-with-xaddrs-template.xml
@@ -10,7 +10,7 @@
         <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
         <wsa:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/ProbeMatches</wsa:Action>
         <wsa:MessageID>urn:uuid:00000000-0000-0000-0000-000000000000</wsa:MessageID>
-        <wsa:RelatesTo>urn:uuid:{}</wsa:RelatesTo>
+        <wsa:RelatesTo>{}</wsa:RelatesTo>
         <wsd:AppSequence InstanceId="{}" SequenceId="urn:uuid:00000000-0000-0000-0000-000000000000" MessageNumber="{}" />
     </soap:Header>
     <soap:Body>

--- a/crates/wsdd-rs/src/test/probe-matches-without-xaddrs-template.xml
+++ b/crates/wsdd-rs/src/test/probe-matches-without-xaddrs-template.xml
@@ -10,7 +10,7 @@
         <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
         <wsa:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/ProbeMatches</wsa:Action>
         <wsa:MessageID>urn:uuid:00000000-0000-0000-0000-000000000000</wsa:MessageID>
-        <wsa:RelatesTo>urn:uuid:{}</wsa:RelatesTo>
+        <wsa:RelatesTo>{}</wsa:RelatesTo>
         <wsd:AppSequence InstanceId="{}" SequenceId="urn:uuid:00000000-0000-0000-0000-000000000000" MessageNumber="{}" />
     </soap:Header>
     <soap:Body>

--- a/crates/wsdd-rs/src/test/probe-template-any-uri-message-id.xml
+++ b/crates/wsdd-rs/src/test/probe-template-any-uri-message-id.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope
+    xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:wsd="http://schemas.xmlsoap.org/ws/2005/04/discovery"
+    xmlns:wsdp="http://schemas.xmlsoap.org/ws/2006/02/devprof"
+>
+    <soap:Header>
+        <wsa:To>urn:schemas-xmlsoap-org:ws:2005:04:discovery</wsa:To>
+        <wsa:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</wsa:Action>
+        <wsa:MessageID>{}</wsa:MessageID>
+    </soap:Header>
+    <soap:Body>
+        <wsd:Probe>
+            <wsd:Types>wsdp:Device</wsd:Types>
+        </wsd:Probe>
+    </soap:Body>
+</soap:Envelope>

--- a/crates/wsdd-rs/src/test/resolve-matches-template.xml
+++ b/crates/wsdd-rs/src/test/resolve-matches-template.xml
@@ -10,7 +10,7 @@
         <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
         <wsa:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/ResolveMatches</wsa:Action>
         <wsa:MessageID>urn:uuid:00000000-0000-0000-0000-000000000000</wsa:MessageID>
-        <wsa:RelatesTo>urn:uuid:{}</wsa:RelatesTo>
+        <wsa:RelatesTo>{}</wsa:RelatesTo>
         <wsd:AppSequence InstanceId="{}" SequenceId="urn:uuid:00000000-0000-0000-0000-000000000000" MessageNumber="{}" />
     </soap:Header>
     <soap:Body>

--- a/crates/wsdd-rs/src/wsd/http/http_server.rs
+++ b/crates/wsdd-rs/src/wsd/http/http_server.rs
@@ -7,11 +7,11 @@ use color_eyre::eyre;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tracing::{Level, event};
-use uuid::fmt::Urn;
 
 use crate::config::Config;
 use crate::max_size_deque::MaxSizeDeque;
 use crate::network_address::NetworkAddress;
+use crate::soap::MessageId;
 use crate::soap::parser::MessageHandler;
 use crate::wsd::http::router::build_router;
 
@@ -31,7 +31,7 @@ impl WSDHttpServer {
         config: Arc<Config>,
         messages_built: Arc<AtomicU64>,
         http_listen_address: SocketAddr,
-        recent_messages: Arc<RwLock<MaxSizeDeque<Urn>>>,
+        recent_messages: Arc<RwLock<MaxSizeDeque<MessageId>>>,
     ) -> Result<WSDHttpServer, std::io::Error> {
         let message_handler = MessageHandler::new(bound_to.clone(), recent_messages);
 

--- a/crates/wsdd-rs/src/wsd/http/http_server.rs
+++ b/crates/wsdd-rs/src/wsd/http/http_server.rs
@@ -159,7 +159,7 @@ mod tests {
         let expected_response = format!(
             include_str!("../../test/get-response-template.xml"),
             Uuid::nil(),
-            Uuid::nil(),
+            Uuid::nil().urn(),
             host_config.hostname,
             host_config.uuid_as_device_uri,
             host_config.uuid_as_device_uri,
@@ -251,7 +251,7 @@ mod tests {
 
         let expected = format!(
             include_str!("../../test/probe-matches-without-xaddrs-template.xml"),
-            client_message_id,
+            client_message_id.urn(),
             host_config.wsd_instance_id,
             host_messages_built.load(Ordering::Relaxed) - 1,
             host_config.uuid_as_device_uri,

--- a/crates/wsdd-rs/src/wsd/http/router.rs
+++ b/crates/wsdd-rs/src/wsd/http/router.rs
@@ -113,7 +113,7 @@ async fn build_response(
         WSDMessage::HostMessage(HostMessage::Get(_get)) => {
             match header.to.as_ref() {
                 Some(to) if to == &config.uuid_as_device_uri => Ok(Some(
-                    builder::Builder::build_get_response(config, header.message_id)?,
+                    builder::Builder::build_get_response(config, &header.message_id)?,
                 )),
                 Some(_) => {
                     // error when `To` doesn't match us
@@ -129,7 +129,7 @@ async fn build_response(
         },
         WSDMessage::HostMessage(HostMessage::Probe(probe)) => {
             // only the probe one is checked for duplicates
-            if message_handler.is_duplicated_msg(header.message_id).await {
+            if message_handler.is_duplicated_msg(&header.message_id).await {
                 event!(
                     Level::DEBUG,
                     message_id = %header.message_id,
@@ -143,7 +143,7 @@ async fn build_response(
                 return Ok(Some(builder::Builder::build_probe_matches(
                     config,
                     messages_built,
-                    header.message_id,
+                    &header.message_id,
                 )?));
             }
 

--- a/crates/wsdd-rs/src/wsd/udp/client.rs
+++ b/crates/wsdd-rs/src/wsd/udp/client.rs
@@ -742,8 +742,8 @@ mod tests {
             .with_body_from_request(move |request| {
                 let metadata: String = format!(
                     include_str!("../../test/get-response-synology.xml"),
-                    Uuid::now_v7(),
-                    Uuid::now_v7(),
+                    Uuid::now_v7().urn(),
+                    Uuid::now_v7().urn(),
                 );
 
                 assert_eq!(
@@ -758,7 +758,7 @@ mod tests {
 
         let hello = format!(
             include_str!("../../test/hello-with-xaddrs-template.xml"),
-            host_message_id,
+            host_message_id.urn(),
             host_config.wsd_instance_id,
             Uuid::now_v7(),
             host_config.uuid_as_device_uri,
@@ -902,8 +902,8 @@ mod tests {
             .with_body_from_request(move |request| {
                 let metadata: String = format!(
                     include_str!("../../test/get-response-synology.xml"),
-                    Uuid::now_v7(),
-                    Uuid::now_v7(),
+                    Uuid::now_v7().urn(),
+                    Uuid::now_v7().urn(),
                 );
 
                 assert_eq!(
@@ -1054,8 +1054,8 @@ mod tests {
 
         let metadata: String = format!(
             include_str!("../../test/get-response-synology.xml"),
-            Uuid::now_v7(),
-            Uuid::now_v7(),
+            Uuid::now_v7().urn(),
+            Uuid::now_v7().urn(),
         );
 
         let device_uri = DeviceUri::new(Uuid::now_v7().as_urn().to_string().into_boxed_str());
@@ -1114,8 +1114,8 @@ mod tests {
 
         let metadata: String = format!(
             include_str!("../../test/get-response-samsung-printer.xml"),
-            Uuid::now_v7(),
-            Uuid::now_v7(),
+            Uuid::now_v7().urn(),
+            Uuid::now_v7().urn(),
         );
 
         let device_uri = DeviceUri::new(Uuid::now_v7().as_urn().to_string().into_boxed_str());
@@ -1171,8 +1171,8 @@ mod tests {
 
         let metadata: String = format!(
             include_str!("../../test/get-response-windows.xml"),
-            Uuid::now_v7(),
-            Uuid::now_v7(),
+            Uuid::now_v7().urn(),
+            Uuid::now_v7().urn(),
         );
 
         let device_uri = DeviceUri::new(Uuid::now_v7().as_urn().to_string().into_boxed_str());
@@ -1237,7 +1237,10 @@ mod tests {
 
         let probe_matches = format!(
             include_str!("../../test/probe-matches-without-xaddrs-template.xml"),
-            host_message_id, host_config.wsd_instance_id, 0, host_config.uuid_as_device_uri
+            host_message_id.urn(),
+            host_config.wsd_instance_id,
+            0,
+            host_config.uuid_as_device_uri
         );
 
         let (multicast_tx, mut multicast_rx) = tokio::sync::mpsc::channel(1);
@@ -1314,7 +1317,10 @@ mod tests {
 
         let probe_matches = format!(
             include_str!("../../test/probe-matches-without-xaddrs-template.xml"),
-            host_message_id, host_config.wsd_instance_id, 0, host_config.uuid_as_device_uri
+            host_message_id.urn(),
+            host_config.wsd_instance_id,
+            0,
+            host_config.uuid_as_device_uri
         );
 
         let (multicast_tx, mut multicast_rx) = tokio::sync::mpsc::channel(1);
@@ -1397,8 +1403,8 @@ mod tests {
             .with_body_from_request(move |request| {
                 let metadata: String = format!(
                     include_str!("../../test/get-response-synology.xml"),
-                    Uuid::now_v7(),
-                    Uuid::now_v7(),
+                    Uuid::now_v7().urn(),
+                    Uuid::now_v7().urn(),
                 );
 
                 assert_eq!(
@@ -1413,7 +1419,7 @@ mod tests {
 
         let probe_matches = format!(
             include_str!("../../test/probe-matches-with-xaddrs-template.xml"),
-            host_message_id,
+            host_message_id.urn(),
             host_config.wsd_instance_id,
             0,
             host_config.uuid_as_device_uri,
@@ -1504,8 +1510,8 @@ mod tests {
             .with_body_from_request(move |request| {
                 let metadata: String = format!(
                     include_str!("../../test/get-response-synology.xml"),
-                    Uuid::now_v7(),
-                    Uuid::now_v7(),
+                    Uuid::now_v7().urn(),
+                    Uuid::now_v7().urn(),
                 );
 
                 assert_eq!(
@@ -1520,7 +1526,7 @@ mod tests {
 
         let resolve_matches = format!(
             include_str!("../../test/resolve-matches-template.xml"),
-            host_message_id,
+            host_message_id.urn(),
             host_config.wsd_instance_id,
             0,
             host_config.uuid_as_device_uri,
@@ -1599,7 +1605,7 @@ mod tests {
 
         let resolve_matches = format!(
             include_str!("../../test/resolve-matches-template.xml"),
-            host_message_id,
+            host_message_id.urn(),
             host_config.wsd_instance_id,
             0,
             host_config.uuid_as_device_uri,
@@ -1669,7 +1675,7 @@ mod tests {
 
         let resolve_matches = format!(
             include_str!("../../test/resolve-matches-template.xml"),
-            host_message_id,
+            host_message_id.urn(),
             host_config.wsd_instance_id,
             0,
             host_config.uuid_as_device_uri,

--- a/crates/wsdd-rs/src/wsd/udp/client.rs
+++ b/crates/wsdd-rs/src/wsd/udp/client.rs
@@ -24,7 +24,7 @@ use crate::soap::parser::hello::Hello;
 use crate::soap::parser::probe_match::ProbeMatch;
 use crate::soap::parser::resolve_match::ResolveMatch;
 use crate::soap::parser::xaddrs::XAddr;
-use crate::soap::{ClientMessage, MulticastMessage};
+use crate::soap::{ClientMessage, MessageId, MulticastMessage};
 use crate::utils::SliceDisplay;
 use crate::utils::task::spawn_with_name;
 use crate::wsd::device::{DeviceUri, WSDDiscoveredDevice};
@@ -36,7 +36,7 @@ pub(crate) struct WSDClient {
     _devices: Arc<RwLock<HashMap<DeviceUri, WSDDiscoveredDevice>>>,
     handle: tokio::task::JoinHandle<()>,
     mc_local_port_tx: Sender<MulticastMessage>,
-    probes: Arc<RwLock<HashMap<Urn, Duration>>>,
+    probes: Arc<RwLock<HashMap<MessageId, Duration>>>,
 }
 
 impl WSDClient {
@@ -54,7 +54,7 @@ impl WSDClient {
         mc_local_port_rx: Receiver<IncomingClientMessage>,
         mc_local_port_tx: Sender<MulticastMessage>,
     ) -> Self {
-        let probes = Arc::new(RwLock::new(HashMap::<Urn, Duration>::new()));
+        let probes = Arc::new(RwLock::new(HashMap::<MessageId, Duration>::new()));
 
         let handle = {
             let cancellation_token = cancellation_token.clone();
@@ -143,7 +143,7 @@ impl WSDClient {
 async fn send_probe(
     cancellation_token: &CancellationToken,
     config: &Arc<Config>,
-    probes: &Arc<RwLock<HashMap<Urn, Duration>>>,
+    probes: &Arc<RwLock<HashMap<MessageId, Duration>>>,
     mc_local_port_tx: &Sender<MulticastMessage>,
 ) -> Result<(), eyre::Report> {
     let future = async move {
@@ -151,7 +151,7 @@ async fn send_probe(
 
         let (probe, message_id) = Builder::build_probe(config)?;
 
-        probes.write().await.insert(message_id, now());
+        probes.write().await.insert(message_id.into(), now());
 
         mc_local_port_tx
             .send(probe)
@@ -165,18 +165,18 @@ async fn send_probe(
         .unwrap_or(Ok(()))
 }
 
-async fn remove_outdated_probes(probes: &Arc<RwLock<HashMap<Urn, Duration>>>) {
+async fn remove_outdated_probes(probes: &Arc<RwLock<HashMap<MessageId, Duration>>>) {
     let now = now();
 
     probes.write().await.retain(|_, sent| is_fresh(*sent, now));
 }
 
-fn record_resolve(resolves: &mut HashMap<Urn, Duration>, message_id: Urn) {
+fn record_resolve(resolves: &mut HashMap<MessageId, Duration>, message_id: Urn) {
     let now = now();
 
     resolves.retain(|_, sent| is_fresh(*sent, now));
 
-    resolves.insert(message_id, now);
+    resolves.insert(message_id.into(), now);
 }
 
 fn is_fresh(sent: Duration, now: Duration) -> bool {
@@ -259,7 +259,7 @@ async fn handle_hello(
     devices: Arc<RwLock<HashMap<DeviceUri, WSDDiscoveredDevice>>>,
     bound_to: &NetworkAddress,
     multicast: &Sender<MulticastMessage>,
-    resolves: &mut HashMap<Urn, Duration>,
+    resolves: &mut HashMap<MessageId, Duration>,
     Hello {
         endpoint,
         raw_xaddrs,
@@ -315,10 +315,10 @@ async fn handle_probe_match(
     config: &Config,
     devices: Arc<RwLock<HashMap<DeviceUri, WSDDiscoveredDevice>>>,
     bound_to: &NetworkAddress,
-    relates_to: Option<Urn>,
-    probes: Arc<RwLock<HashMap<Urn, Duration>>>,
+    relates_to: Option<MessageId>,
+    probes: Arc<RwLock<HashMap<MessageId, Duration>>>,
     mc_local_port_tx: &Sender<MulticastMessage>,
-    resolves: &mut HashMap<Urn, Duration>,
+    resolves: &mut HashMap<MessageId, Duration>,
     ProbeMatch {
         endpoint,
         raw_xaddrs,
@@ -375,8 +375,8 @@ async fn handle_resolve_match(
     config: &Config,
     devices: Arc<RwLock<HashMap<DeviceUri, WSDDiscoveredDevice>>>,
     bound_to: &NetworkAddress,
-    relates_to: Option<Urn>,
-    resolves: &HashMap<Urn, Duration>,
+    relates_to: Option<MessageId>,
+    resolves: &HashMap<MessageId, Duration>,
     ResolveMatch {
         endpoint,
         raw_xaddrs,
@@ -507,7 +507,7 @@ async fn listen_forever(
     mut mc_wsd_port_rx: Receiver<IncomingClientMessage>,
     mut mc_local_port_rx: Receiver<IncomingClientMessage>,
     mc_local_port_tx: Sender<MulticastMessage>,
-    probes: Arc<RwLock<HashMap<Urn, Duration>>>,
+    probes: Arc<RwLock<HashMap<MessageId, Duration>>>,
 ) {
     // Note: we bind on the interface's name.
     // This is to ensure we send out requests via the interface that we received the XML message on
@@ -620,6 +620,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::network_interface::NetworkInterface;
+    use crate::soap::MessageId;
     use crate::soap::parser::xaddrs::XAddr;
     use crate::test_utils::xml::to_string_pretty;
     use crate::test_utils::{build_config, build_message_handler_with_network_address};
@@ -688,7 +689,7 @@ mod tests {
         assert_matches!(result, Ok(()));
 
         // the resolve's message id must be recorded to accept the future ResolveMatches
-        assert!(resolves.contains_key(&Uuid::nil().urn()));
+        assert!(resolves.contains_key(&MessageId::from(Uuid::nil().urn())));
 
         let expected = format!(
             include_str!("../../test/resolve-template.xml"),
@@ -1252,7 +1253,7 @@ mod tests {
         let probes = {
             let mut hash_map = HashMap::new();
 
-            hash_map.insert(host_message_id.urn(), now());
+            hash_map.insert(MessageId::from(host_message_id.urn()), now());
 
             Arc::new(RwLock::new(hash_map))
         };
@@ -1277,7 +1278,7 @@ mod tests {
         assert_matches!(result, Ok(()));
 
         // the resolve's message id must be recorded to accept the future ResolveMatches
-        assert!(resolves.contains_key(&Uuid::nil().urn()));
+        assert!(resolves.contains_key(&MessageId::from(Uuid::nil().urn())));
 
         let expected = format!(
             include_str!("../../test/resolve-template.xml"),
@@ -1330,7 +1331,10 @@ mod tests {
         let probes = {
             let mut hash_map = HashMap::new();
 
-            hash_map.insert(host_message_id.urn(), Duration::from_secs(100));
+            hash_map.insert(
+                MessageId::from(host_message_id.urn()),
+                Duration::from_secs(100),
+            );
 
             Arc::new(RwLock::new(hash_map))
         };
@@ -1431,7 +1435,7 @@ mod tests {
         let probes = {
             let mut hash_map = HashMap::new();
 
-            hash_map.insert(host_message_id.urn(), now());
+            hash_map.insert(MessageId::from(host_message_id.urn()), now());
 
             Arc::new(RwLock::new(hash_map))
         };
@@ -1536,7 +1540,7 @@ mod tests {
         let resolves = {
             let mut hash_map = HashMap::new();
 
-            hash_map.insert(host_message_id.urn(), now());
+            hash_map.insert(MessageId::from(host_message_id.urn()), now());
 
             hash_map
         };
@@ -1686,7 +1690,10 @@ mod tests {
         let resolves = {
             let mut hash_map = HashMap::new();
 
-            hash_map.insert(host_message_id.urn(), Duration::from_secs(100));
+            hash_map.insert(
+                MessageId::from(host_message_id.urn()),
+                Duration::from_secs(100),
+            );
 
             hash_map
         };

--- a/crates/wsdd-rs/src/wsd/udp/host.rs
+++ b/crates/wsdd-rs/src/wsd/udp/host.rs
@@ -430,7 +430,7 @@ mod tests {
 
         let expected = format!(
             include_str!("../../test/resolve-matches-template.xml"),
-            client_message_id,
+            client_message_id.urn(),
             host_config.wsd_instance_id,
             host_messages_built.load(Ordering::Relaxed) - 1,
             host_config.uuid_as_device_uri,
@@ -453,7 +453,7 @@ mod tests {
             client_message_id
         );
 
-        handles_probe_generic(client_message_id, &probe).await;
+        handles_probe_generic(client_message_id.urn(), &probe).await;
     }
 
     #[tokio::test]
@@ -465,7 +465,7 @@ mod tests {
             client_message_id
         );
 
-        handles_probe_generic(client_message_id, &probe).await;
+        handles_probe_generic(client_message_id.urn(), &probe).await;
     }
 
     #[tokio::test]
@@ -476,7 +476,7 @@ mod tests {
             client_message_id
         );
 
-        handles_probe_generic(client_message_id, &probe).await;
+        handles_probe_generic(client_message_id.urn(), &probe).await;
     }
 
     #[tokio::test]
@@ -489,44 +489,10 @@ mod tests {
             MESSAGE_ID
         );
 
-        let host_message_handler = build_message_handler();
-
-        let host_config = Arc::new(build_config(Uuid::now_v7(), "host-instance-id"));
-        let host_messages_built = Arc::new(AtomicU64::new(0));
-
-        let (header, message) = host_message_handler
-            .deconstruct_message(
-                probe.as_bytes(),
-                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 100, 5), 5000)),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(header.message_id.as_ref(), MESSAGE_ID);
-
-        let probe = message.into_probe().unwrap();
-
-        let response = handle_probe(
-            &host_config,
-            &host_messages_built,
-            &header.message_id,
-            &probe,
-        )
-        .unwrap()
-        .unwrap();
-
-        let response = String::from_utf8_lossy(response.as_ref()).into_owned();
-
-        // the reply echoes the id verbatim
-        assert!(
-            response.contains(
-                "<wsa:RelatesTo>uuid:0a6dc791-2be6-4991-9af1-454778a1917a</wsa:RelatesTo>"
-            ),
-            "RelatesTo must echo the incoming MessageID byte-for-byte"
-        );
+        handles_probe_generic(MESSAGE_ID, &probe).await;
     }
 
-    async fn handles_probe_generic(client_message_id: Uuid, probe: &str) {
+    async fn handles_probe_generic(client_message_id: impl std::fmt::Display, probe: &str) {
         let host_message_handler = build_message_handler();
 
         // host

--- a/crates/wsdd-rs/src/wsd/udp/host.rs
+++ b/crates/wsdd-rs/src/wsd/udp/host.rs
@@ -6,7 +6,6 @@ use color_eyre::eyre;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio_util::sync::CancellationToken;
 use tracing::{Level, event};
-use uuid::fmt::Urn;
 
 use crate::config::Config;
 use crate::multicast_handler::{IncomingHostMessage, OutgoingMessage};
@@ -14,7 +13,7 @@ use crate::network_address::NetworkAddress;
 use crate::soap::builder::{self, Builder};
 use crate::soap::parser::probe::Probe;
 use crate::soap::parser::resolve::Resolve;
-use crate::soap::{HostMessage, MulticastMessage, UnicastMessage};
+use crate::soap::{HostMessage, MessageId, MulticastMessage, UnicastMessage};
 use crate::utils::task::spawn_with_name;
 
 /// handles WSD requests coming from UDP datagrams.
@@ -151,7 +150,7 @@ async fn send_hello(
 pub fn handle_probe(
     config: &Config,
     messages_built: &AtomicU64,
-    relates_to: Urn,
+    relates_to: &MessageId,
     probe: &Probe,
 ) -> Result<Option<UnicastMessage>, eyre::Report> {
     if probe.types.is_empty() || probe.requested_type_match() {
@@ -176,7 +175,7 @@ fn handle_resolve(
     config: &Config,
     messages_built: &AtomicU64,
     target_uuid: uuid::Uuid,
-    relates_to: Urn,
+    relates_to: &MessageId,
     resolve: &Resolve,
 ) -> Result<Option<UnicastMessage>, eyre::Report> {
     if resolve.addr_urn == target_uuid.urn() {
@@ -231,14 +230,14 @@ async fn listen_forever(
         // dispatch based on the SOAP Action header
         let response = match message {
             HostMessage::Probe(probe) => {
-                handle_probe(&config, &messages_built, header.message_id, &probe)
+                handle_probe(&config, &messages_built, &header.message_id, &probe)
             },
             HostMessage::Resolve(resolve) => handle_resolve(
                 address,
                 &config,
                 &messages_built,
                 config.uuid,
-                header.message_id,
+                &header.message_id,
                 &resolve,
             ),
             HostMessage::Get(_) => {
@@ -423,7 +422,7 @@ mod tests {
             &host_config,
             &host_messages_built,
             host_config.uuid,
-            header.message_id,
+            &header.message_id,
             &resolve,
         )
         .unwrap()
@@ -480,6 +479,53 @@ mod tests {
         handles_probe_generic(client_message_id, &probe).await;
     }
 
+    #[tokio::test]
+    async fn handles_probe_with_non_urn_message_id() {
+        // the WS-Discovery spec's own example Probe uses this form, MessageID is `xs:anyURI`
+        const MESSAGE_ID: &str = "uuid:0a6dc791-2be6-4991-9af1-454778a1917a";
+
+        let probe = format!(
+            include_str!("../../test/probe-template-any-uri-message-id.xml"),
+            MESSAGE_ID
+        );
+
+        let host_message_handler = build_message_handler();
+
+        let host_config = Arc::new(build_config(Uuid::now_v7(), "host-instance-id"));
+        let host_messages_built = Arc::new(AtomicU64::new(0));
+
+        let (header, message) = host_message_handler
+            .deconstruct_message(
+                probe.as_bytes(),
+                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 100, 5), 5000)),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(header.message_id.as_ref(), MESSAGE_ID);
+
+        let probe = message.into_probe().unwrap();
+
+        let response = handle_probe(
+            &host_config,
+            &host_messages_built,
+            &header.message_id,
+            &probe,
+        )
+        .unwrap()
+        .unwrap();
+
+        let response = String::from_utf8_lossy(response.as_ref()).into_owned();
+
+        // the reply echoes the id verbatim
+        assert!(
+            response.contains(
+                "<wsa:RelatesTo>uuid:0a6dc791-2be6-4991-9af1-454778a1917a</wsa:RelatesTo>"
+            ),
+            "RelatesTo must echo the incoming MessageID byte-for-byte"
+        );
+    }
+
     async fn handles_probe_generic(client_message_id: Uuid, probe: &str) {
         let host_message_handler = build_message_handler();
 
@@ -503,7 +549,7 @@ mod tests {
         let response = handle_probe(
             &host_config,
             &host_messages_built,
-            header.message_id,
+            &header.message_id,
             &probe,
         )
         .unwrap()


### PR DESCRIPTION
WS-Addressing declares `MessageID` and `RelatesTo` as `xs:anyURI`. We parsed them as `urn:uuid:` URNs and dropped everything else before deduplication, without a reply.
The WS-Discovery spec's own example Probe uses `uuid:...` without the `urn:` prefix, so spec-valid peers were ignored. Upstream treats the id as an opaque string and replies.

Incoming ids are now an opaque `MessageId`, deduplicated by byte-wise equality and echoed verbatim into `RelatesTo`.
The verbatim echo also satisfies section 5.3, we previously re-serialized the id lowercase.

Our own outgoing ids are still UUID URNs.
