### PR TITLE
refactor!: drop `-v` and `-s`

### DIFF
--- a/crates/wsdd-rs/src/cli.rs
+++ b/crates/wsdd-rs/src/cli.rs
@@ -4,7 +4,7 @@ use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use clap::{ArgAction, Parser};
+use clap::Parser;
 use color_eyre::eyre;
 use color_eyre::eyre::WrapErr as _;
 use tracing::{Level, event};
@@ -25,7 +25,7 @@ use crate::wsd::device::DeviceUri;
     long_version = concat!("- Web Service Discovery Daemon, v", env!("CARGO_PKG_VERSION")),
     color = clap::ColorChoice::Always
 )]
-struct CliArgs {
+pub struct CliArgs {
     #[arg(short, long, help = "interface or address to use")]
     interface: Vec<String>,
 
@@ -39,9 +39,6 @@ struct CliArgs {
 
     #[arg(short = 'U', long, help = "UUID for the target device")]
     uuid: Option<Uuid>,
-
-    #[arg(short, long, action = ArgAction::Count, help = "increase verbosity")]
-    verbose: u8,
 
     #[arg(
         short,
@@ -74,9 +71,6 @@ struct CliArgs {
 
     #[arg(short = '6', long, group = "ip", help = "use only IPv6")]
     ipv6only: bool,
-
-    #[arg(short, long, help = "log only level and message")]
-    shortlog: bool,
 
     #[arg(short, long, help = "preserve case of the provided/detected hostname")]
     preserve_case: bool,
@@ -117,18 +111,29 @@ fn float_to_duration_parser(value: &str) -> Result<Duration, String> {
     Duration::try_from_secs_f32(value).map_err(|error| error.to_string())
 }
 
-pub fn parse_cli() -> Result<Config, eyre::Report> {
-    parse_cli_from(env::args_os())
+pub fn parse_args() -> Result<CliArgs, eyre::Report> {
+    parse_args_from(env::args_os())
 }
 
-pub fn parse_cli_from<I, T>(from: I) -> Result<Config, eyre::Report>
+fn parse_args_from<I, T>(from: I) -> Result<CliArgs, eyre::Report>
 where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
     // TODO: How do we return a specific error (e.g. 3 for the user spec's value parser) when an error occurs?
-    let args = CliArgs::try_parse_from(from)?;
+    Ok(CliArgs::try_parse_from(from)?)
+}
 
+#[cfg(test)]
+pub fn parse_cli_from<I, T>(from: I) -> Result<Config, eyre::Report>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    to_config(parse_args_from(from)?)
+}
+
+pub fn to_config(args: CliArgs) -> Result<Config, eyre::Report> {
     let interfaces: Vec<InterfaceFilter> = if args.interface.is_empty() {
         event!(Level::WARN, "no interface given, using all interfaces");
 
@@ -152,12 +157,6 @@ where
             .split_once('.')
             .map(|(first, _rest)| Box::from(first))
             .unwrap_or(hostname)
-    };
-
-    let verbosity = match args.verbose {
-        0 => Level::WARN,
-        1 => Level::INFO,
-        _ => Level::DEBUG,
     };
 
     let uuid = match args.uuid {
@@ -208,13 +207,11 @@ where
         hoplimit: args.hoplimit,
         uuid,
         uuid_as_device_uri,
-        verbosity,
         hostname,
         full_hostname: full_hostname.into_boxed_str(),
         no_autostart: args.no_autostart,
         no_http: args.no_http,
         bind_to,
-        shortlog: args.shortlog,
         chroot: args.chroot,
         user: args.user,
         discovery: args.discovery,
@@ -348,7 +345,6 @@ mod tests {
     use std::path::Path;
 
     use pretty_assertions::{assert_eq, assert_matches};
-    use tracing::Level;
 
     use crate::cli::{parse_cli_from, to_interface_filter, to_listen};
     use crate::config::{InterfaceFilter, PortOrSocket};
@@ -407,27 +403,6 @@ mod tests {
         let result = parse_cli_from(["wsdd-rs", "--interface", "eth0", "--interface", "eth0:0"]);
 
         assert_matches!(result, Err(_));
-    }
-
-    #[test]
-    fn no_verbose() {
-        let config = parse_cli_from(["wsdd-rs"]).unwrap();
-
-        assert_eq!(config.verbosity, Level::WARN);
-    }
-
-    #[test]
-    fn verbose() {
-        let config = parse_cli_from(["wsdd-rs", "--verbose"]).unwrap();
-
-        assert_eq!(config.verbosity, Level::INFO);
-    }
-
-    #[test]
-    fn very_verbose() {
-        let config = parse_cli_from(["wsdd-rs", "--verbose", "--verbose"]).unwrap();
-
-        assert_eq!(config.verbosity, Level::DEBUG);
     }
 
     #[test]

--- a/crates/wsdd-rs/src/config.rs
+++ b/crates/wsdd-rs/src/config.rs
@@ -16,21 +16,10 @@ pub struct Config {
     pub hoplimit: u8,
     pub uuid: Uuid,
     pub uuid_as_device_uri: DeviceUri,
-    #[cfg_attr(not(test), expect(unused, reason = "WIP"))]
-    pub verbosity: Level,
     pub hostname: Box<str>,
     pub full_hostname: Box<str>,
     pub no_autostart: bool,
     pub no_http: bool,
-    //     if args.shortlog:
-    //         fmt = '%(levelname)s: %(message)s'
-    //     else:
-    //         fmt = '%(asctime)s:%(name)s %(levelname)s(pid %(process)d): %(message)s'
-
-    //     logging.basicConfig(level=log_level, format=fmt)
-    //     logger = logging.getLogger('wsdd')
-    #[expect(unused, reason = "WIP")]
-    pub shortlog: bool,
     pub chroot: Option<PathBuf>,
     pub user: Option<(u32, u32)>,
     pub discovery: bool,

--- a/crates/wsdd-rs/src/main.rs
+++ b/crates/wsdd-rs/src/main.rs
@@ -52,7 +52,7 @@ use tracing_subscriber::{EnvFilter, Layer as _};
 
 use crate::address_monitor::create_address_monitor;
 use crate::build_env::get_build_env;
-use crate::cli::parse_cli;
+use crate::cli::{CliArgs, parse_args, to_config};
 use crate::config::{Config, PortOrSocket};
 use crate::constants::WSD_MAX_KNOWN_MESSAGES;
 use crate::max_size_deque::MaxSizeDeque;
@@ -69,11 +69,11 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 fn build_filter() -> (EnvFilter, Option<eyre::Report>) {
     fn build_default_filter() -> EnvFilter {
         EnvFilter::builder()
-            .parse(format!("INFO,{}=TRACE", env!("CARGO_CRATE_NAME")))
+            .parse("warn")
             .expect("Default filter should always work")
     }
 
-    let (filter, parsing_error) = match env::var(EnvFilter::DEFAULT_ENV) {
+    match env::var(EnvFilter::DEFAULT_ENV) {
         Ok(user_directive) => match EnvFilter::builder().parse(user_directive) {
             Ok(filter) => (filter, None),
             Err(error) => (build_default_filter(), Some(eyre::Report::new(error))),
@@ -82,9 +82,7 @@ fn build_filter() -> (EnvFilter, Option<eyre::Report>) {
         Err(error @ VarError::NotUnicode(_)) => {
             (build_default_filter(), Some(eyre::Report::new(error)))
         },
-    };
-
-    (filter, parsing_error)
+    }
 }
 
 fn init_tracing(filter: EnvFilter) -> Result<(), eyre::Report> {
@@ -109,6 +107,23 @@ fn main() -> ExitCode {
         .install()
         .expect("Failed to install panic handler");
 
+    // parse before tracing is set up, so `--help`/`--version` and usage errors
+    // are not preceded by log output
+    let args = match parse_args() {
+        Ok(args) => args,
+        Err(error) => {
+            // this prints the error in color and exits
+            // can't do anything else until
+            // https://github.com/clap-rs/clap/issues/2914
+            // is merged in
+            if let Some(clap_error) = error.downcast_ref::<clap::error::Error>() {
+                clap_error.exit();
+            }
+
+            return Err::<Infallible, _>(error).report();
+        },
+    };
+
     let (env_filter, parsing_error) = build_filter();
 
     init_tracing(env_filter).expect("Failed to set up tracing");
@@ -127,7 +142,7 @@ fn main() -> ExitCode {
         .block_on(async {
             // explicitly launch everything in a spawned task
             // see https://docs.rs/tokio/latest/tokio/attr.main.html#non-worker-async-function
-            let handle = spawn_with_name("main task runner", start_tasks());
+            let handle = spawn_with_name("main task runner", start_tasks(args));
 
             flatten_shutdown_handle(handle).await
         });
@@ -149,20 +164,6 @@ fn print_header() {
         build_env.get_target(),
         build_env.get_target_cpu().unwrap_or("base cpu variant"),
     );
-}
-
-fn get_config() -> Result<Arc<Config>, eyre::Report> {
-    let config = Arc::new(parse_cli().inspect_err(|error| {
-        // this prints the error in color and exits
-        // can't do anything else until
-        // https://github.com/clap-rs/clap/issues/2914
-        // is merged in
-        if let Some(clap_error) = error.downcast_ref::<clap::error::Error>() {
-            clap_error.exit();
-        }
-    })?);
-
-    Ok(config)
 }
 
 fn try_chroot(config: &Config) -> Option<Shutdown> {
@@ -217,11 +218,11 @@ fn try_chroot(config: &Config) -> Option<Shutdown> {
 
 /// starts all the tasks, such as the web server, the key refresh, ...
 /// ensures all tasks are gracefully shutdown in case of error, `CTRL+c` or `SIGTERM`.
-async fn start_tasks() -> Shutdown {
+async fn start_tasks(args: CliArgs) -> Shutdown {
     print_header();
 
-    let config = match get_config() {
-        Ok(config) => config,
+    let config = match to_config(args) {
+        Ok(config) => Arc::new(config),
         Err(error) => return Shutdown::from(error),
     };
 


### PR DESCRIPTION
Both flags were parsed into `Config` and never read. Wiring them up would have meant reimplementing a subset of what `RUST_LOG` already does, so they are gone instead.

A verbosity counter cannot express per-target directives, and we have no consumers to keep compatible. The default filter is now `warn`, where it was `INFO,{crate}=TRACE`, which made a stock run unusably noisy.

`main` now parses the CLI before initializing tracing. Clap parsing emits no logs, so it can run first, and `--help`, `--version` and usage errors are no longer preceded by a log line. Building the config does log, so it stays after.

BREAKING CHANGE: `-v`, `--verbose`, `-s` and `--shortlog` are rejected as unknown arguments. A unit file or script passing them fails to start instead of ignoring them. Set `RUST_LOG` for level and per-target filtering.
