### PR TITLE
fix: emit `Types` before `XAddrs` in `Hello`

### DIFF
--- a/crates/wsdd-rs/src/soap/builder/body/hello.rs
+++ b/crates/wsdd-rs/src/soap/builder/body/hello.rs
@@ -41,13 +41,15 @@ where
     ) -> Result<(), xml::writer::Error> {
         writer.write(XmlEvent::start_element("wsd:Hello"))?;
 
+        // element order is the `HelloType` sequence, see documentation/ws-discovery.pdf, Appendix II
         add_endpoint_reference(writer, &config.uuid_as_device_uri)?;
+
+        // TODO: make this optional, like adding `xaddr`
+        add_types(writer, constants::WSDP_TYPE_DEVICE_COMPUTER)?;
 
         // THINK: Microsoft does not send the transport address here due to privacy reasons. Could make this optional.
         add_xaddr(writer, config, self.xaddr)?;
 
-        // TODO: make this optional, like adding `xaddr` ^
-        add_types(writer, constants::WSDP_TYPE_DEVICE_COMPUTER)?;
         add_metadata_version(writer)?;
 
         writer.write(XmlEvent::end_element())?;

--- a/crates/wsdd-rs/src/test/hello-with-xaddrs-template.xml
+++ b/crates/wsdd-rs/src/test/hello-with-xaddrs-template.xml
@@ -17,8 +17,8 @@
             <wsa:EndpointReference>
                 <wsa:Address>{}</wsa:Address>
             </wsa:EndpointReference>
-            <wsd:XAddrs>http://{}:{}/{}</wsd:XAddrs>
             <wsd:Types>wsdp:Device pub:Computer</wsd:Types>
+            <wsd:XAddrs>http://{}:{}/{}</wsd:XAddrs>
             <wsd:MetadataVersion>1</wsd:MetadataVersion>
         </wsd:Hello>
     </soap:Body>


### PR DESCRIPTION
`HelloType` is a sequence of `EndpointReference`, `Types`, `Scopes`, `XAddrs`, `MetadataVersion` ([documentation/ws-discovery.pdf](https://github.com/kristof-mattei/wsdd-rs/blob/b9578f48b39f4fa6e85a60df057efeefec1424c4/documentation/ws-discovery.pdf), Appendix II, page 33). 

We emitted `XAddrs` before `Types`, so every `Hello` we broadcast was schema-invalid, including the one that announces us at startup.

Upstream doesn't have the problem because it omits `Types` from `Hello` entirely.
